### PR TITLE
Fix missing content in Polish chapter 3 translation

### DIFF
--- a/translations/polish/chapter3_po.tex
+++ b/translations/polish/chapter3_po.tex
@@ -108,17 +108,181 @@ W II wieku chrześcijaństwo istniało w trzech wielkich odłamach: gnostyków (
 Ten nurt rzymski pozostał celowo niejednoznaczny, zdolny mówić o Ojcu zarówno w kategoriach żydowskich, jak i greckich, nie rozstrzygając sprawy.
 Pozostałe dwa nurty były całkowicie jednoznaczne: oba twierdziły, że Ojciec nie jest YHWH.
 Gnostycy opisywali Boga Mojżesza jako niższą lub nieświadomą moc, podczas gdy marcjoniści posuwali się dalej, nazywając go złym.
-Gdyby Jezus sam głosił YHWH jako swego Ojca, takie poglądy nie mogłyby stać się dominującymi nurtami chrześcijańskiej wiary
+Gdyby Jezus sam głosił YHWH jako swego Ojca, takie poglądy nie mogłyby stać się dominującymi nurtami chrześcijańskiej wiary.
+Fakt, że tak właśnie uczynili, pokazuje, iż najwcześniejsze głoszenie Boga Ojca zostało przyjęte w kategoriach greckich, a nie związanych z imieniem przymierza Izraela.
+Dopiero później Kościół rzymski narzucił utożsamienie Ojca z YHWH jako doktrynę oficjalną.
+
+\subsection{Antropologia: nauka Jezusa o duszy}\label{subsec:jesus-doctrine-of-the-soul}
+
+Różnica między Bogiem Mojżesza a Bogiem Platona ujawnia się najwyraźniej w tym, czym — według każdej z tych tradycji — jest człowiek.
+Pismo Hebrajskie traktuje \emph{nefesz} jako życiowy oddech, który ginie razem z ciałem i schodzi do Szeolu pozbawiony świadomości.
+Myśl grecka traktuje \emph{psyche} jako nieśmiertelną istotę, która przeżywa ciało i powraca do swego boskiego źródła.
+Jezus konsekwentnie naucza modelu greckiego.
+„Nie bójcie się tych, którzy zabijają ciało, lecz duszy zabić nie mogą" ustanawia absolutne rozróżnienie między śmiertelnym ciałem a nieśmiertelną \emph{psyche}.
+„Cóż pomoże człowiekowi, choćby cały świat zyskał, a na swej duszy szkodę poniósł?" zakłada istnienie „ja", którego nie można sprowadzić do życia cielesnego.
+„Dziś będziesz ze mną w raju" zakłada natychmiastową świadomość po śmierci, a nie długi sen Szeolu.
+Przypowieść o Łazarzu i bogaczu ukazuje dwóch ludzi w pełni świadomych, mówiących, pamiętających i doświadczających moralnej odpłaty po śmierci.
+Przemienienie ukazuje Mojżesza i Eliasza żywych, świadomych i rozpoznawalnych w stanie niematerialnym całe stulecia po ich śmierci.
+Nic z tego nie należy do antropologii Tory.
+Wszystko to należy do antropologii średniego platonizmu i zhellenizowanego judaizmu.
+Jezus nie naucza o wskrzeszeniu uśpionego życia-oddechu; naucza o przetrwaniu świadomej duszy.
+A ta antropologia odpowiada jego nauce o Bogu.
+Bóg, który jest czystym umysłem i wiecznym Ojcem, naturalnie rządzi istotami, których prawdziwym życiem jest dusza, a nie ciało.
+Bóg, który jest czczony „w duchu i w prawdzie", przemawia do stworzeń określonych przez ich wewnętrzną, nieśmiertelną istotę.
+Metafizyka i antropologia wznoszą się razem: grecki Ojciec i nieśmiertelna dusza należą do tego samego świata intelektualnego.
+
+\subsection{Pater Noster}\label{subsec:pater-noster}
+Choć można próbować spierać się o to, który obraz Boga przedstawiony w Nowym Testamencie mógł zostać później zniekształcony przez autorów pragnących pozyskać czytelników, o wiele trudniej podważyć to, czego Jezus sam nauczał o Bogu, którego nazywał „Ojcem".
+
+W katechizmach i komentarzach \emph{Pater Noster} przedstawia się jako modlitwę zasadniczo żydowską.
+Zachowały się dwie ewangeliczne wersje — Mateusz 6,9–13 (Kazanie na Górze) i Łukasz 11,2–4 (prośba ucznia).
+Jej zwyczajowa interpretacja wygląda tak:
+• „Ojcze nasz, któryś jest w niebie" — echo formuł synagogalnych (np. późniejszego Kadisz: „Wywyższone i uświęcone niech będzie wielkie Imię Jego").
+• „Święć się Imię Twoje" = uświęcanie Imienia YHWH (już świętego w Izraelu).
+• „Przyjdź królestwo Twoje / bądź wola Twoja jako w niebie, tak i na ziemi" = nadzieja Izraela z Księgi Daniela i Proroków.
+• „Chleba naszego powszedniego daj nam dzisiaj" = typologia manny lub psalmiczna opatrzność.
+• „I odpuść nam nasze długi\ldots{} jako i my odpuszczamy" = etyka Jubileuszu/kapłańska.
+• „I nie wódź nas na pokuszenie, ale nas zbaw ode złego" = pokusy moralne; Boża ochrona przed grzechem.
+W takim ujęciu modlitwa jest w całości „drugotemplem żydowskim".
+
+\subsubsection{Dlaczego standardowa żydowska interpretacja się załamuje}
 
 Przy uważnej lekturze modlitwa wyraźnie unika znaków przymierza Izraela.
 Nie ma Synaju, nie ma Tory, nie ma Syjonu, nie ma Abrahama, nie ma szabatu, nie ma ofiar — nie pojawia się żaden z motywów, które stanowiły oś pobożności judaizmu Drugiej Świątyni.
 Zauważmy, dlaczego modlitwa nie pasuje do standardowej żydowskiej interpretacji:
-• Ojciec powszechny, w niebiosach, a nie Bóg przymierza „który cię wyprowadził z Egiptu”.
+• Ojciec powszechny, w niebiosach, a nie Bóg przymierza „który cię wyprowadził z Egiptu".
 • Uświęcone Imię bez Tetragramu i bez Świątyni.
 • Królestwo, które zstępuje z nieba na ziemię (oś kosmiczna), a nie przywrócenie rządów Dawida na Górze Syjon.
-• Prośba o chleb powszedni nie odsyła ani do manny (która nie była „powszednia”), ani do psalm
+• Prośba o chleb powszedni nie odsyła ani do manny (która nie była „powszednia"), ani do psalmicznej opatrzności (która nie jest „powszednia").
+• Próba (greckie peirasmos) i ocalenie od Złego brzmią jak apokaliptyczna walka z pożerającym przeciwnikiem, a nie jak ogólnikowa prośba o ochronę przed prywatnymi pokusami.
+Standardowa interpretacja „działa" tylko dlatego, że importuje tło, którego tekst nie dostarcza, ignorując jednocześnie obrazy, które dostarcza.
 
-\label{subsec:jesus-christ-referring-to-our-father-in-heaven-and-yhwh}
+\subsubsection{Egipska interpretacja słoneczno-królewska}
+
+Co fascynujące, gdy odczytać modlitwę w świetle egipskiej liturgii słoneczno-królewskiej, każda jej fraza znajduje swoje miejsce bez napięcia.
+\begin{enumerate}
+    \def\labelenumi{(\alph{enumi})}
+    \item
+    „Ojcze nasz, któryś jest w niebie" — Egipskie hymny do Atona i Amona-Ra zwracają się do najwyższego boga jako do ojca wszystkich; faraon jest synem Słońca. Zwrot jest kosmiczny, nie etniczny. To właściwy rejestr tej modlitwy.
+    \item „Święć się Imię Twoje" (ἁγιασθήτω τὸ ὄνομά σου) — Egipska pobożność koncentruje się na Imieniu (rèn), bardzo podobnie do hebrajskiej koncepcji świętości Imienia YHWH.
+    Amun dosłownie znaczy „Ukryty"; jego ukryte Imię jest wysławiane i chronione. Refreny takie jak „Imię Twoje jest Amun — Amun, Amun" są liturgiczne.
+    Jest to dokładnie uświęcanie Imienia bez jego wymawiania — znacznie bliższy odpowiednik niż zwyczajowo opisywane praktyki tetragramu Mojżesza w modlitwie świeckiej.
+    \item
+    „Przyjdź królestwo Twoje. Bądź wola Twoja jako w niebie, tak i na ziemi." — Każdego świtu Słońce przywraca Maat (porządek) w niebiosach i, poprzez króla, na ziemi. Królestwo słoneczne jest rurociągiem woli/porządku z nieba na ziemię. To dokładnie struktura tej prośby.
+    \item „Chleba naszego powszedniego daj nam dzisiaj" (τὸν ἄρτον\ldots{} τὸν ἐπιούσιον) — Wielki Hymn do Atona wysławia boga, który „codziennie czyni chleb dla ludzkości". Egipskie formuły ofiarne („chleb i piwo, codziennie") to standardowy język świątynny.
+    Ta linia jest niemal cytatem co do sensu.
+    \item
+    „I odpuść nam nasze długi, jako i my odpuszczamy naszym dłużnikom." — Egipt ujmuje sprawiedliwość jako ważenie na sądzie — serce ważone wobec pióra Maat. „Bycie oczyszczonym" (uwolnionym od moralnego ciężaru/długu) to różnica między przetrwaniem a unicestwieniem.
+    Zwrot etyczny („jako i my odpuszczamy") wiąże czciciela z praktykowaniem Maat społecznie. To znacznie bliższe egipskiemu moralnemu ciężarowi/długowi niż późniejsze prawnicze drobiazgowości.
+    \item „I nie wódź nas na pokuszenie, ale zbaw nas ode Złego." (μὴ εἰσενέγκῃς\ldots{} εἰς πειρασμόν\ldots{} ῥῦσαι ἀπὸ τοῦ πονηροῦ) — Peirasmos = próba/przejście, nie przede wszystkim „pokusa". Odczytane apokaliptycznie to wielka próba; odczytane wizualnie to scena sądu. A Zły nie jest abstrakcją: w ikonografii egipskiej dusza, która nie przeszła próby, jest pożerana przez Ammit (krokodyl-lew-hipopotam), gdy szale się przechylają. „Zbaw nas od pożeracza" — dokładnie tak działa ta scena.
+    \item
+    „Bo Twoje jest królestwo i moc, i chwała na wieki wieków." (ὅτι σοῦ ἐστιν ἡ βασιλεία καὶ ἡ δύναμις καὶ ἡ δόξα) — Ta trójczłonowa formuła — królestwo, moc, chwała — pojawia się na greckich inskrypcjach ku czci królów ptolemejskich, Seleucydów i cesarzy rzymskich. Jest to standardowy sposób ogłaszania, kto dzierży najwyższą władzę. Modlitwa przekierowuje tę formułę: władza należy do \textit{Ciebie} (Boga), nie do Cezara. Każdy chrześcijanin odmawiający tę modlitwę codziennie składał publiczną przysięgę lojalności rywalowi imperium. To zakończenie umiejscawia całą modlitwę w ideologii królewsko-słonecznej.
+    \item
+    „Amen." — Zanim uznamy, że „amen" jest bezpiecznie i wyłącznie hebrajskie, zwróćmy uwagę na praktykę liturgiczną: egipskie hymny i responsoria kończą się aklamacjami Amuna; kongregacyjne wezwanie-odpowiedź wzmacnia Imię. Zarówno w piśmie hebrajskim, jak i egipskim słowo było pierwotnie zapisywane tylko spółgłoskami *MN* (hebrajski: אמן; egipski: jmn), bez samogłosek. W hebrajskim daje to „amen" (trwały/prawdziwy); w egipskim „Amun" (Ukryty). Fonetyczne pokrywanie się nie jest przypadkowe, lecz odzwierciedla wspólną podstawę aklamacyjną. Aleksander Wielki twierdził, że pochodzi od Zeusa-Ammona; królowie ptolemejscy stylizowali się podobnie. Powiedzieć „Amen" oznacza więc przypieczętować modlitwę w rejestrze ukrytego Imienia Amuna — boga podtrzymującego prawomocność królewską. Funkcjonalnie i fonetycznie „Wszyscy mówią Amun/Amen!" — taka jest logika.
+\end{enumerate}
+
+Konkluzja: każda fraza pasuje do liturgii słoneczno-królewskiej bez napięcia.
+Choć można argumentować, że Jezus lub Mateusz po prostu nieświadomie zapożyczyli kilka wyrażeń z hymnów egipskich, istnieje niepodważalny dowód, że to nie przypadek.
+Mateusz opatruje jałmużnę, modlitwę i post tym samym refrenem: „Ojciec twój, który widzi w ukryciu, odda tobie" (6,4; 6,6; 6,18).
+To nie przypadkowy dodatek — to dokładny tytuł Amuna, „Ukrytego", i dokładnie sposób, w jaki działa teologia Amuna.
+Modlitwa Pańska jest wpleciona w te trzy nauki, a sama modlitwa jest wprowadzona opisem Boga jako ukrytego Ojca.
+Co uderzające, nie są to marginalne elementy narracji.
+Jałmużna, modlitwa i post to trzy filary Wielkiego Postu, od zawsze centralne dla wiary chrześcijańskiej, a Modlitwa Pańska jest prawdopodobnie najczęściej cytowanym tekstem, jaki kiedykolwiek ktokolwiek napisał.
+Jednocześnie Mateusz stara się wykazać głęboką wierność pobożności judaizmu Drugiej Świątyni.
+Cytuje Proroków wszędzie, gdzie może, i niemal niepojęte jest, by świadomie wprowadził rdzeń wierzeń egipskiej teologii królewskiej do swojej Ewangelii.
+To, w połączeniu z centralnym miejscem Modlitwy Pańskiej w pobożności chrześcijańskiej sięgającym Didache, najwcześniejszego podręcznika liturgicznego, najprawdopodobniej z I wieku, oznacza, że nauka ta z dużym prawdopodobieństwem sięga samego Jezusa.
+Tak więc modlitwa zaczyna się zwrotem do ukrytego Ojca w niebie, a kończy przypieczętowaniem aklamacją Amun/Amen — doskonale spójna liturgia słoneczno-królewska.
+
+Interpretacja „wyłącznie żydowska" musi przemilczać kosmiczną gramatykę modlitwy; interpretacja egipska nie musi.
+
+Wizualnym odpowiednikiem tej liturgii jest promienna aureola — korona słoneczna widoczna na wizerunkach Aleksandra, Ptolemeuszy i późniejszych cesarzy rzymskich — obrazowanie, które wczesna sztuka chrześcijańska swobodnie przeniosła na Jezusa jako Syna kosmicznego Ojca.
+
+\subsubsection{Dlaczego ta ikonografia była wciąż żywa w I wieku}
+
+To nie jest pył epoki brązu przypadkowo przyklejony do tekstu z I wieku.
+To ciągła kultura: • Egipt w Kanaanie (ok. 1500--1150 p.n.e.).
+Przez stulecia południowy Lewant był prowincją egipską.
+Jerozolima pojawia się w archiwum z Amarny (ok. 1350 p.n.e.), gdzie jej władca Abdi-Heba pisze do faraona jako do „mojego Słońca".
+Egipskie garnizony i kult funkcjonowały w Beth-Shean, Jaffie, Deir el-Balah itd.
+• Dawidowy rdzeń psalmiczny (ok. 1150--970 p.n.e.).
+Najstarsze językowo psalmy są przesycone motywami słońca, światła, nieba, ziemi, królewskości i boskiego panowania (Ps 19; 29; 68; 84; 104).
+Czyta się je jak hebrajskie adaptacje hymnów solarnych, a nie homilie do Tory.
+• Rewolucja Atena i supremacja Amuna-Ra.
+Aten-monoteizm Echnatona upada, lecz Amun-Ra powraca silniejszy; solarno-monoteistyczna presja nigdy nie znika.
+• Egipt ptolemejski (III--I w. p.n.e.).
+Dynastia tworzy kult Serapisa/Izydy i utrzymuje jawny królewski wymiar solarny.
+Śmierć Kleopatry (30 p.n.e.) mieści się w pamięci dziadków pokolenia Jezusa.
+• Środowisko Jezusa.
+Roszczenie do tytułu „króla Żydów" sytuowało się w rzymskiej Syrii-Palestynie, nasyconej ikonografią Heliosa/Sola.
+Wczesna sztuka chrześcijańska bez oporów maluje Chrystusa jako Heliosa; świętym dniem jest niedziela.
+Solarno-królewski idiom nie jest obcy — to woda, w której wszyscy pływali.
+Widziany przez ten ciąg kulturowy, \emph{Pater Noster} nie zapożycza kilku egipskich fraz; należy do solarno-królewskiego rejestru biegnącego od Aten → Amun-Ra → królewskości ptolemejskiej prosto do I wieku.
+W kosmopolitycznych ośrodkach takich jak Aleksandria i Antiochia modlitwy same krążyły i stapiały idiomy; Modlitwa Pańska wpisuje się w ten świat wspólnego solarno-królewskiego języka zrozumiałego ponad tradycjami.
+
+\subsubsection{Pogodzenie ram żydowskich i egipskich}
+
+Tak, modlitwę można odmawiać w żydowskim kluczu (i tak ją odmawiano).
+Łukasz osadza ją w lekcji o zależności; Mateusz ujmuje ją w ramy pobożności i przebaczenia.
+Sformułowania rzeczywiście nakładają się na późniejszy język synagogalny („święć się Imię Jego").
+Ale to nakładanie dowodzi podatności na adaptację, nie pochodzenia.
+Co istotne, modlitwa: • omija szczegóły przymierza, • mówi w uniwersalnej solarno-kosmicznej gramatyce, oraz • idealnie wpisuje się w egipską/ptolemejską teologię królewską.
+Lepszym modelem jest fuzja: oddanie Najwyższemu Bogu Izraela wchłonęło, przetłumaczyło i ponownie wykorzystało dominującą solarno-królewską gramatykę, którą rozumieli wszyscy.
+Jeśli Jezus stoi — jak zakłada nasza teza — jako pretendent królewski w cieniu świeżo upadłego świata ptolemejskiego, to ta modlitwa brzmi nie jako formuła synagogalna, lecz jako dynastyczna modlitwa solarno-królewska: niebiański Ojciec (Słońce), zstępujące królestwo, codzienne utrzymanie, sprawiedliwe wagi, wybawienie od pożeracza — Amen.
+
+\subsubsection{Mapa fraza po frazie dla czytelnika}
+
+• Ojciec w niebie → źródło solarne (Aten/Amun-Ra) i królewskie synostwo.
+• Uświęcone Imię → ukryte Imię wywyższone (rèn Amuna).
+• Przyjdź królestwo / bądź wola → Maat przywrócona z nieba na ziemię przez króla.
+• Chleba powszedniego → bóg słońca, który codziennie daje chleb.
+• Odpuść długi → odciąż moralny ciężar na wadze; wprowadzaj Maat wobec innych.
+• Nie wódź na próbę → oszczędź nam próby/sądu.
+• Wybaw od Złego → ocal od pożeracza, który pochłania tych, którzy zawiedli.
+• Amen → wspólnotowa pieczęć, funkcjonalnie identyczna z aklamacją Amuna.
+
+Dlaczego ma to znaczenie dla Dawida i Jezusa: Dawid (ok. 1150--970 p.n.e.) żyje dostatecznie blisko horyzontu amarneńskiego, by egipska solarna królewskość była jeszcze pamięcią żywą; najstarsze psalmy brzmią tak, jak brzmią, ponieważ wyrosły w tym świecie.
+Jezus (wczesny I w. n.e.) stoi w zasięgu żywej pamięci ptolemejskiej monarchii solarnej.
+Jeśli jest — jak argumentuje ta książka — figurą królewską wewnątrz tamtej teologii politycznej, \emph{Pater Noster} jest dokładnie tym typem modlitwy solarno-królewskiej, jakiej nauczałby pretendent: przekłada najstarszą egipską gramatykę królewskości na formę, którą jego zwolennicy mogą odmawiać wszędzie.
+To jest odczytanie, które wyjaśnia wszystko, co tekst faktycznie mówi — bez wprowadzania Synaju — oraz tłumaczy, dlaczego modlitwa przekraczała języki i imperia tak bezwysiłkowo.
+(Ta ciągłość liturgiczna opiera się na języku przysięgi omówionym w Rozdziale~2 i przygotowuje grunt pod obraz baranka-amunowego omówiony w Sekcji~\ref{par:jesus-is-the-lamb-of-god-who-takes-away-the-sins-of-the-world.}.)
+
+\paragraph{Niedziela.} Na koniec powinniśmy spojrzeć także na Dzień Pański, niedzielę, dzień Słońca.
+Rzymianie we wczesnym imperium nadal stosowali ośmiodniowy cykl oznaczany literami A–H, z dniem targowym co osiem dni.
+Żydzi zachowywali tydzień siedmiodniowy, ale nie używali nazw planetarnych, numerując dni od szabatu.
+Siedmiodniowy tydzień planetarny, stworzony w ptolemejskiej Aleksandrii, był ramą, którą przyjęli chrześcijanie.
+Filon z Aleksandrii odzwierciedla żydowski tydzień numerowany, podczas gdy współczesne kalendarze egipskie używały już schematu planetarnego.
+I to chrześcijanie wprowadzili ten siedmiodniowy tydzień do świata rzymskiego, łącząc Słońce i Pana — a nie odwrotnie.
+
+\paragraph{Ojciec nasz w niebie.}
+Ludzie zawsze rozumieli, że Słońce daje im wszystko, czego potrzebują: ciepło, światło, pożywienie, kwiaty w parku, odbicia na jeziorze.
+Słońce było rozpoznawane jako ojciec życia w czasach starożytnych i współczesnych.
+Motyw Słońca jako ojca wszystkich ludzi albo ojca dynastii rządzącej pojawia się w wielu kontekstach i religiach.
+„Jesteśmy z materii gwiazd", cytat Carla Sagana powtarzany przez współczesnych naukowców, jest nowoczesnym sposobem wyrażenia, że jesteśmy dziećmi Słońca.
+Głównym epitetem Amuna-Ra było „it nṯrw", ojciec bogów, a wiele modlitw nazywało go „tym, który stwarza ludzkość, który ukształtował wszystko, co żyje, ojcem ojców wszystkich bogów".
+Hymn do Atena nazywa Słońce „ojcem wszystkiego, co stworzył".
+W Imperium Inków Inti był uważany zarówno za Boga Słońca, jak i przodka wszystkich Inków.
+Podobnie w indyjskiej dynastii solarnej królowie wywodzili swoje pochodzenie od Surji, Boga Słońca.
+W japońskiej religii Shintō Amaterasu jest Boginią Słońca i mityczną pramatką japońskiej rodziny cesarskiej.
+W Grecji Zeus, ojciec bogów i ludzi, był powszechnie nazywany naszym Ojcem.
+Choć nie był ściśle bogiem Słońca, Zeus — jako przedstawiciel nieba — wnosił motyw ojcostwa dokładnie z tego samego powodu.
+
+\paragraph{Aureola.}
+W tym kontekście nie wolno zapominać, że w całej historii przedstawień Jezusa, Maryi i wszystkich świętych ukazywano ich z aureolą, kręgiem światła wokół głowy, symbolizującym ich świętość.
+Jednak to, co aureola wyraźnie i jednoznacznie przedstawia, to tarcza Słońca.
+Była to już ikonografia Ra, postaci z solarą tarczą nad głową.
+
+To samo dotyczy boskich i świętych postaci na subkontynencie indyjskim, gdzie symbol aureoli był równie stary, a nawet starszy niż w Egipcie.
+\emph{Prabhāmaṇḍala} była jeszcze bardziej wyeksponowana i identyczna z tą używaną w chrześcijaństwie, symbolizując boskie światło, świętość i duchową moc przedstawianej postaci, a jednocześnie zawsze była jednoznacznie rozpoznawana jako blask Słońca.
+
+Faraonów aż do czasów Jezusa przedstawiano również z tarczą słoneczną nad głową.
+Choć większość współczesnych przedstawień Kleopatry nie ukazuje jej z tarczą słoneczną, liczne jej egipskie wizerunki z epoki ukazują ją z nią bardzo wyraźnie.
+
+Tarcza słoneczna jako znak Syna Bożego wykonującego wolę Ojca nie zniknęła nawet wraz z nadejściem chrześcijaństwa, gdyż była używana w przedstawieniach Konstantyna Wielkiego, Justyniana I, a nawet Karola Wielkiego.
+Choć jest mało prawdopodobne, by twórcy portretów w średniowieczu świadomie myśleli o tarczy słonecznej, ukazuje to, jak głęboko zakorzeniona była ta ikonografia w chrześcijańskiej świadomości.
+
+Żadna z tych postaci nie była świętą, lecz wszystkie przedstawiano z aureolą — solarną reprezentacją tarczy Boga Ojca, symbolizującą boski autorytet stojący za ich ziemskim panowaniem.
+
+\subsection{Jezus Chrystus mówiący o Ojcu Naszym w niebie i YHWH}\label{subsec:jesus-christ-referring-to-our-father-in-heaven-and-yhwh}
 Mowa Jezusa konsekwentnie odróżnia \emph{Ojca w niebiosach} (którego istotą są miłosierdzie, hojność, przebaczenie) od \emph{Kyrios} przywoływanego w pismach Izraela i jego religii publicznej.
 Ewangelie zachowują to rozróżnienie na trzech poziomach: (1) własnego zwracania się Jezusa do Boga jako „mój Ojciec” i nauczania o „Ojcu naszym”; (2) jego polemiki z Judejczykami, którzy roszczą sobie prawo do stwierdzenia, że Bóg jest ich Ojcem; (3) jego cytowania Pisma, gdzie Tetragram (YHWH) pojawia się po grecku jako \emph{Kyrios}, równocześnie z przeniesieniem tytułu \emph{Kyrios} jako królewskiego określenia na samego siebie.
 


### PR DESCRIPTION
## Summary
- Fixed truncated fragment 2 in Polish chapter 3 translation
- Added missing "Anthropology: Jesus's doctrine of the soul" subsection
- Added missing "Pater Noster" introduction and subsubsections:
  - Why This Imagery Was Still Alive in the First Century
  - Reconciling Jewish and Egyptian Frames
  - Clause-by-Clause Map for the Reader
  - Sunday, Our Father in Heaven, and Halo paragraphs
- Polish translation now has 907 lines (was 743), properly covering the English original (861 lines)

## Test plan
- [ ] Verify CI builds Polish PDF successfully
- [ ] Check that all sections from English chapter 3 are present in Polish version

🤖 Generated with [Claude Code](https://claude.com/claude-code)