### PR TITLE
Add Peter/Seleucid geographic division evidence

### DIFF
--- a/chapter5.tex
+++ b/chapter5.tex
@@ -903,6 +903,15 @@ The rural Syrian hinterland surrounding Antioch preserves Aramaic funerary and d
 Mark's Greek fits a bilingual Antiochene environment where urban Greek and rural Aramaic interpenetrated.
 These Aramaic insertions are Mark's linguistic world, not Jesus's.
 
+The ancient division of Anatolia placed the Aegean coast in the Greek world and the interior in the Seleucid sphere.
+Paul's cities---Corinth, Philippi, Thessalonica, Ephesus---belong to the Aegean coastal world.
+Peter's provinces---Pontus, Galatia, Cappadocia, Bithynia---belong to the Seleucid interior.
+This cultural and political divide existed long before Rome and persisted long after.
+Syria is absent from 1~Peter's address because Peter writes from Antioch, not to it.
+An apostle does not write to his own base; he writes from it.
+Peter's designation for his audience---``elect exiles of the Dispersion'' (1~Pet 1:1)---names scattered believers across the Seleucid lands, just as James's ``twelve tribes'' names the Judean sphere and Paul's ``sons of men'' names the Aegean Greeks.
+Each apostle writes from a metropolitan center to a distinct quadrant of the Greek world.
+
 \subsection{Why the Evidence Shows Jesus Did Not Speak Aramaic}
 
 The scholarly claim that Jesus spoke Aramaic rests entirely on the Aramaic phrases preserved in the Gospel of Mark.


### PR DESCRIPTION
## Summary

Establishes the geographic division between Paul's Aegean sphere and Peter's Seleucid sphere using the ancient Hellenistic division of Anatolia (not Roman provincial categories).

## Changes (Chapter 5, lines 906-913)

**The ancient division:**
- Aegean coast = Greek world (Paul's cities)
- Anatolian interior = Seleucid sphere (Peter's provinces)
- This divide existed long before Rome and persisted long after

**Paul vs Peter:**
| Apostle | Territory | Cities/Provinces |
|---------|-----------|------------------|
| Paul | Aegean coastal world | Corinth, Philippi, Thessalonica, Ephesus |
| Peter | Seleucid interior | Pontus, Galatia, Cappadocia, Bithynia |

**FROM/TO argument:**
- Syria absent from 1 Peter because Peter writes FROM Antioch, not TO it
- An apostle writes from his metropolitan center to his mission field

**Four-pole parallel:**
- James = "twelve tribes" (Judean sphere)
- Paul = "sons of men" (Aegean sphere)
- Peter = "elect exiles of the Dispersion" (Seleucid sphere)

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Check geographic claims against Hellenistic maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)