### PR TITLE
Add Dragon as imperial succession + Four Royal Titles system

### DIFF
--- a/chapter5.tex
+++ b/chapter5.tex
@@ -464,9 +464,17 @@ Rome did not even realize the new religion's goal was to restore the Eastern Emp
 Alexandria was the capital of the Greek Empire and the center of the Hellenistic world and yet there are no missions or letters to Alexandria.}\label{subsec:alexandria-was-the-capital-of-the-greek-empire-and-the-center-of-the-hellenistic-world-and-yet-there-are-no-missions-or-letters-to-alexandria.}
 
 The absence of Alexandria in the New Testament is striking, especially considering its significance.
-Alexandria was erased from the text, as it was the origin city of Apollos, as well as some of the other companions of Paul such as Mark, Demas, and Luke.
+Alexandria hosted the largest Jewish community outside Palestine, the only city where Jewish population rivaled Jerusalem itself.
+The city produced the Septuagint, the Wisdom literature, Philo's philosophical corpus, and the conceptual vocabulary that fills the Gospel of John.
+Yet no epistle addresses Alexandria; no mission narrative targets it.
+This silence follows the same pattern visible in the other apostolic spheres.
+An apostle writes from his metropolitan center to his mission field, not to his point of origin.
+James does not write to Jerusalem; Peter does not write to Antioch; Paul does not write to Ephesus as mission target.
+Alexandria is absent because John writes from Alexandria, not to it.
+The city appears only obliquely, as the origin of Apollos (Acts 18:24), who arrives already trained in the Scriptures and requiring only correction on baptism.
+This is not the profile of a new convert but of someone formed in an already-established Alexandrian community.
 The omission is best explained as deliberate suppression, precisely because Alexandria was already the center of the movement.
-Just as the Old Testament largely omits the Ptolemaic empire despite its centrality, so the New Testament minimizes Alexandria while still presuming its leadership.
+Just as the Old Testament largely omits the Ptolemaic empire despite its centrality, so the New Testament minimizes Alexandria while presuming its leadership.
 
 \section{Acts of the Apostles}\label{subsec:acts-of-the-apostles}
 


### PR DESCRIPTION
## Summary

Completes the political theology of Revelation and establishes the four-pole title system matching the four-gospel/four-kingdom framework.

## Changes

### 1. Dragon = Imperial Succession Ideology (lines 1013-1020)

- Rev 13:2: Dragon GIVES authority to Beast — dragon is UPSTREAM of Rome
- Dragon = inherited Hellenistic divine kingship ideology
- Succession: Persia → Alexander → Diadochi → Rome
- Rome inherited imperial theology; Rome did not invent it
- "The beast can be wounded and replaced; the dragon persists"

### 2. Son of Man = Aegean Political Title (lines 786-794)

- ἄνθρωπος = representative/corporate ruler in Greek political language
- Aegean kingship is human-first (man raised above men), not divine-first like Egypt
- θηρίον vs ἄνθρωπος = beast vs lawful ruler (already Greek before Daniel)
- Daniel 7 translates directly into this framework
- "The Romans execute him as a king, not as a prophet, because they hear the political claim correctly"

### 3. The Four Royal Titles (new subsection, lines 925-942)

| Title | Pole | Meaning |
|-------|------|---------|
| **Son of God** | Ptolemaic/Alexandria | Pharaoh = literal son of god; Ptolemies adopted |
| **Son of Man** | Aegean/Antigonid | Representative human ruler, judge of nations |
| **King of the Jews** | Judean/Hasmonean | Davidic lineage, Temple-centered |
| **Κύριος (Lord)** | Seleucid/Antioch | Administrative sovereignty, jurisdictional |

**Evidence for κύριος = Seleucid:**
- Seleucid royal letters: ὁ βασιλεὺς κύριος τῶν πόλεων
- Acts 2:36: "God made him both Lord and Christ" = appointment language
- Psalm 110 in Mark: lordship transfer, not genealogy
- κύριος is NOT native to Aegean, Egyptian, or Judean kingship

### 4. Alexandria FROM/TO Pattern Strengthened (lines 466-477)

- Alexandria = largest Jewish diaspora outside Palestine
- City produced Septuagint, Wisdom literature, Philo, John's vocabulary
- FROM/TO pattern: apostles write FROM origin TO field
- James/Jerusalem, Peter/Antioch, Paul/Ephesus parallels
- Alexandria absent because John writes FROM Alexandria, not TO it
- Apollos evidence: arrived trained, not converted

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Check Greek text renders correctly (Κύριος, ἄνθρωπος, θηρίον)

🤖 Generated with [Claude Code](https://claude.com/claude-code)