### PR TITLE
Fix scholarly precision in Chapter 4 Synoptic section

### DIFF
--- a/chapter4.tex
+++ b/chapter4.tex
@@ -1077,14 +1077,16 @@ This period of fasting and testing parallels the purification and trial rites kn
 This whole sequence is often divided into separate pericopes in modern editions, which obscures its unity.
 
 When Mark writes that the Spirit descended "like a dove," this is not an arbitrary image.
-Zeus was widely known as relaying his divine messages through a white dove.
-Hesiod describes the doves of Dodona at one of the oldest and most famous oracles of Zeus: the priestesses were called "doves," and prophecy itself was said to be carried from the oak of Zeus.
-In this context, the dove was a recognized emblem of Zeus' descent and communication, in the same way that the Holy Spirit later came to be portrayed in Christian tradition.
+Zeus was widely known as relaying his divine messages through doves.
+Herodotus describes doves as the founding messenger-vehicle of Zeus's oracle at Dodona, one of the oldest and most famous sanctuaries in the Greek world.
+Hesiod likewise places doves at Dodona's sacred oak, and the priestesses themselves were called Peleiades ("doves").
+Homer and Plato both treat Dodona as a Zeus site where the god's will is delivered as speech from the oak.
+The dove-Zeus connection extends beyond Dodona: Achaean League coinage from Sikyon pairs a laureate head of Zeus with a dove flying within an olive wreath, directly linking the god and the bird in civic iconography.
+In this context, the dove was a recognized emblem of Zeus's descent and communication, and Hellenized audiences would have heard this register alongside Jewish Spirit traditions.
 
-This event is often separated into separated titled chapters that confuse the reader into thinking these are separate events, not a continuous narrative of a single event.
+This event is often separated into separate titled chapters that confuse the reader into thinking these are separate events, not a continuous narrative of a single event.
 Yet read continuously, this description of a coronation ceremony is unmistakable.
 Every coronation in Ptolemaic Egypt was accompanied by a ritual of purification, fasting, and testing in the desert.
-Zeus descended as a white dove to speak to the public is also an exceedingly common motif in Hellenistic royal iconography.
 
 \subsection{11.3 Liturgical hymns as royal proclamation}\label{subsec:liturgical-hymns-as-royal-proclamation}
 


### PR DESCRIPTION
## Summary
- Soften Herod 10-12AD dating title from assertive fact to "minority reconstruction"
- Replace "later insertion" terminology with proper textual-critical language ("redactional layer/expansion")
- Reframe dove/Zeus imagery: now framed as symbolism "Hellenized audiences would recognize" rather than direct derivation
- Downgrade Mattathias ben Theophilus identification from "substantial textual evidence" to "speculative reconstruction"
- Add fragmentary preservation note to Gospel of Hebrews section

Completes Chapter 4 review (all 4 parts done).

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Review each fix preserves the argument while improving scholarly defensibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)