### PR TITLE
Convert all inline citations to formal \cite commands

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -136,9 +136,9 @@ We need to point out that when Matthew cites prophecies, they are not the most i
 There would be absolutely no problem linking Jesus to a prophecy in Jerusalem or in Ar-Ram had he been born there---each of these three, Jerusalem, Bethlehem, and Ar-Ram, were ancient royal or priestly centers perfectly consistent with a Davidic family background.
 This geography alone makes the Bethlehem tradition far more credible than a later invention---it fits both the family’s sphere and the political landscape of Judea.
 
-Among early non-canonical sources, the \textit{Protoevangelium of James} is one of the very few apocryphal texts that offers an early and seemingly independent testimony.
+Among early non-canonical sources, the \textit{Protoevangelium of James} \cite{protoevangelium} is one of the very few apocryphal texts that offers an early and seemingly independent testimony.
 It likewise places the birth in a cave at Bethlehem and was extremely influential throughout Christian history, shaping the Catholic and Orthodox understanding of Mary and the Nativity.
-A specific cave in Bethlehem was already allegedly venerated by Christians in Origen, suggesting a continuity of local memory reaching back to the earliest period.
+A specific cave in Bethlehem was already allegedly venerated by Christians in Origen \cite{origen:contracels}, suggesting a continuity of local memory reaching back to the earliest period.
 
 \section{Where did Jesus grow up?}\label{sec:where-did-jesus-grow-up}
 
@@ -223,11 +223,11 @@ The argument for a prominent Nazareth stands on its own, whereas the identificat
 There is a famous list of twenty-four destinations of Jewish settlers after the destruction of the Second Temple in 70~CE.
 This resettlement from Judea to Galilee was organized by the Roman authorities to prevent further rebellions in Judea.
 Although the list is not complete, it does appear that Nazareth was listed twice as a destination---once for a certain Jeshua and once for Happizzez---while Sepphoris, the central city of Galilee, was not listed at all.
-Epiphanius (\textit{De Mensuris et Ponderibus} §14) explicitly records: ``Jeshua in Nazara'' and ``Happizzez in Nazara,'' the same city appearing twice in the roster.
+Epiphanius \cite[\S14]{epiphanius:mensuris} explicitly records: ``Jeshua in Nazara'' and ``Happizzez in Nazara,'' the same city appearing twice in the roster.
 These twenty-four destinations were all cities in central Galilee, no more than about thirty kilometers apart.
 Being a destination of two priestly groups is a strong confirmation that Nazareth must have been one of the largest and most important towns in Galilee.
 
-Pliny, in his \textit{Natural History} (5.81), names a ``tetrarchy of the Nazareni'' in Syria Coele.
+Pliny \cite[5.81]{pliny:nh} names a ``tetrarchy of the Nazareni'' in Syria Coele.
 A tetrarchy was a minor principality, literally ``rule of a fourth,'' ranking below a kingdom; an ethnarch (``ruler of a nation'') stood between king and tetrarch in the Roman hierarchy of client rulers.
 The passage reads:
 ``Apamea ... ab eo dividitur Marsya flumine a tetrarchia Nazareni.''
@@ -490,12 +490,12 @@ What exactly is a gospel or *euangelion*?
 
 In the wider Mediterranean, *euangelion* was not originally a Christian word at all but a political one.
 In the Greek cities it denoted the proclamation of royal victories or accessions.
-Plutarch (*Numa* 23.3) uses the word for the “good news” brought from the battlefield, and papyri from Egypt (e.g. P.Oxy. 42.3010, AD 9) announce *euangelion* when generals like Germanicus had triumphed.
+Plutarch \cite[23.3]{plutarch:lives} uses the word for the "good news" brought from the battlefield, and papyri from Egypt (e.g. P.Oxy. 42.3010, AD 9) announce *euangelion* when generals like Germanicus had triumphed.
 It was the technical word for victory reports and ruler festivals across the Hellenistic world.
 
 Later, in the Roman imperial cult, the same term was taken over for Augustus and his heirs.
 At Priene (9 BC) the decree for Augustus calls his birthday “the beginning of the good news (*euangelia*) for the world,” and a similar decree from Halicarnassus (2 BC) speaks of his honors as “good news to all the cities.”
-Josephus (*Jewish War* 4.618) describes the rise of Vespasian as *euangelia* proclaimed to the people, and Cassius Dio (51.19.6) reports Actium’s outcome in these terms.
+Josephus \cite[4.618]{josephus:war} describes the rise of Vespasian as *euangelia* proclaimed to the people, and Cassius Dio \cite[51.19.6]{cassiusdio:romanhistory} reports Actium's outcome in these terms.
 By the first century, then, *euangelion* had become the stock word for a ruler’s accession or military victory, whether in Greek or Roman settings.
 
 Thus when Mark begins with “The beginning of the gospel of Jesus Christ, Son of God” (Mk 1:1), he is casting Jesus in precisely that political idiom.
@@ -668,7 +668,7 @@ Jesus’ flight to Egypt thus fits the pattern of dynastic exile, not of a rusti
 
 Celsus, a highly educated Greek philosopher and one of the earliest critics of Christianity, not only repeated the Panthera accusation but also charged that Jesus fled to Egypt and learned the arts that Egyptians ``pride themselves on.''
 For such claims to carry weight in debate, he must have drawn on solid sources; otherwise they would have had no impact.
-Origen's rebuttal preserves a separate Jewish polemic that names a soldier Pantera as Jesus's father, and later rabbinic texts --- Shabbat 104b and Tosefta Hullin 2:22 --- combine this slander with claims that he brought spells and esoteric knowledge out of Egypt.
+Origen's rebuttal \cite{origen:contracels} preserves a separate Jewish polemic that names a soldier Pantera as Jesus's father, and later rabbinic texts --- Shabbat 104b and Tosefta Hullin 2:22 --- combine this slander with claims that he brought spells and esoteric knowledge out of Egypt.
 These attacks arise from different communities, different centuries, and different agendas, yet they converge on the same point: Jesus was associated with Egypt in a way his enemies could not ignore.
 Enemies invent lies, but they do not usually invent the same lie independently, especially when such claims risk undermining their own credibility in debate.
 If the Egyptian episode were merely a Christian myth, hostile writers would have dismissed it outright; instead they weaponized it, suggesting that the memory of a real Egyptian exile was already too widespread to deny.
@@ -815,8 +815,8 @@ It is also significant that James is introduced not on his own merits but as “
 
 \section{Cornelius Tacitus}\label{sec:cornelius-tacitus}
 
-Cornelius Tacitus (c.~56--120 AD) was a Roman senator and historian whose \emph{Annals} and \emph{Histories} are considered among the finest works of Latin prose; his aristocratic status and access to official archives make him one of our most reliable sources for first-century Rome.
-He mentions Jesus in his \emph{Annals}, written around 116 AD.
+Cornelius Tacitus (c.~56--120 AD) was a Roman senator and historian whose \emph{Annals} \cite{tacitus:annals} and \emph{Histories} \cite{tacitus:histories} are considered among the finest works of Latin prose; his aristocratic status and access to official archives make him one of our most reliable sources for first-century Rome.
+He mentions Jesus in his \emph{Annals} \cite{tacitus:annals}, written around 116 AD.
 The passage reads: “Christus, the founder of the name, was put to death in the reign of Tiberius by the procurator Pontius Pilate.”
 The overwhelming majority of scholars consider this passage to be authentic, and the evidence against interpolation is very strong.
 This is both because the style is purely Tacitean and because it would have been almost impossible for Christian scribes to insert such a line into a work so widely copied and closely studied.
@@ -833,10 +833,10 @@ In this correspondence, written around 112 AD, Pliny mentions Christians and rep
 The authenticity of this letter is sometimes debated, but regardless of the debate, it shows that in Roman eyes the movement defined itself not around “Jesus of Nazareth” or “Jesus the wise man” but around Christos.
 Even though the letter adds little to the historical evidence of Jesus’ life, it confirms again that what endured in public memory was his title as Christ, the anointed ruler.
 
-Suetonius, in his *Life of Claudius* written around 121 AD, refers to unrest in Rome “at the instigation of Chrestus.”
+Suetonius \cite{suetonius:claudius}, writing around 121 AD, refers to unrest in Rome “at the instigation of Chrestus.”
 Although brief, this phrasing shows that in the eyes of Roman chroniclers Jesus was remembered as a disruptive political figure, not simply a preacher.
 
-Later still, Lucian of Samosata, in the *Passing of Peregrinus* written around 170 AD, mocked Christians for worshiping “the same crucified sophist” and for living by his laws.
+Later still, Lucian of Samosata \cite{lucian:peregrinus}, writing around 170 AD, mocked Christians for worshiping “the same crucified sophist” and for living by his laws.
 Here Jesus appears in recognizably Greek categories, not as a Jewish prophet but as a sophist and philosopher, remembered as a lawgiver who founded a community.
 
 This later record is important because it shows continuity.
@@ -857,7 +857,7 @@ Josephus records that James was executed by the high priest Ananus in 62 AD, a d
 This continuity --- Jesus followed by James, then Simon, and then others of the family --- fits the pattern of dynastic succession rather than spontaneous charismatic leadership.
 
 Early sources remembered this family line as the δεσπόσυνοι (\textit{despósynoi}), the "relatives of the Lord."
-Hegesippus, quoted by Eusebius, tells us that members of this family were brought before the emperor Domitian.
+Hegesippus, quoted by Eusebius \cite{eusebius:he}, tells us that members of this family were brought before the emperor Domitian.
 They were interrogated about their descent and property, and when they showed their hands calloused from farming and declared they owned only a few acres, Domitian released them as harmless.
 But the fact that the emperor himself summoned them shows that the bloodline of Jesus was still seen as politically significant a generation after the crucifixion.
 Roman emperors did not waste time on prophets; they feared potential dynasties.
@@ -1037,13 +1037,13 @@ This symptom would predispose Jesus to a condition in which premature death coul
 Joseph of Arimathea and Nicodemus did receive an agreement from Pilate to pull him from the cross early, and Jesus could have simply survived the trauma and barely alive.
 
 Josephus provides the single most important historical precedent for survival after crucifixion, and this evidence must be placed at the front of any serious analysis.
-In \emph{War} 4.5.2 (333), Josephus describes seeing three of his acquaintances crucified, petitioning the Roman commander for their removal, and discovering that one of them survived after being taken down.
+In \cite[4.5.2]{josephus:war}, Josephus describes seeing three of his acquaintances crucified, petitioning the Roman commander for their removal, and discovering that one of them survived after being taken down.
 This passage demonstrates that elite Jews could intervene in crucifixions, secure early removal, and that survival was medically possible when the victim was taken down quickly.
 Josephus is not theorizing but reporting a direct eyewitness event under Roman authority, and his account mirrors the exact pattern Joseph of Arimathea would have followed under Pilate.
 The precedent is clear: elite intervention could interrupt the execution process, and early removal could preserve life.
-Philo describes a similar episode in \emph{Against Flaccus} 83--84 where crucified Jews in Alexandria were removed from their crosses in response to elite petition, revealing that such interventions were not unique to Jerusalem.
+Philo describes a similar episode in \cite[83--84]{philo:flaccum} where crucified Jews in Alexandria were removed from their crosses in response to elite petition, revealing that such interventions were not unique to Jerusalem.
 The passage indicates that Roman authorities in multiple provinces could be pressured by influential Jews to modify execution procedures, including premature removal.
-Josephus notes in \emph{War} 4.317 that Romans allowed Jews to bury crucified individuals during festivals in order to prevent public unrest.
+Josephus notes in \cite[4.317]{josephus:war} that Romans allowed Jews to bury crucified individuals during festivals in order to prevent public unrest.
 This practice provided a legal and administrative pathway for Jesus' immediate burial in a private tomb and shows that Pilate's concession was not irregular but fully consistent with Roman policy during Jewish holy days.
 By the third day, he appears to have recovered enough to walk, speak with the apostles, and display his wounds.
 He may have died weeks later from infection, after which belief spread that he had been resurrected and ascended to heaven.
@@ -1064,8 +1064,8 @@ Crucifixion was a prolonged form of execution designed to last for hours, if not
 For Pilate to be surprised, it could imply that Jesus' death occurred more quickly than usual, which is significant because:
 
 Comparative data from Roman literature confirms that Jesus' time on the cross was radically shorter than normal execution practice.
-Seneca notes in \emph{Epistle} 101.14 that crucifixion victims ``linger, dying for hours on end,'' emphasizing that death is slow, gradual, and prolonged.
-Quintilian states in \emph{Declamation} 274 that victims do not die quickly unless their legs are broken, a procedure that accelerates suffocation by removing the ability to raise the body.
+Seneca notes in \cite[101.14]{seneca:epistles} that crucifixion victims ``linger, dying for hours on end,'' emphasizing that death is slow, gradual, and prolonged.
+Quintilian states in \cite[274]{quintilian:declamation} that victims do not die quickly unless their legs are broken, a procedure that accelerates suffocation by removing the ability to raise the body.
 Against this background, Pilate's astonishment in Mark 15:44 becomes a medical and procedural red flag because Jesus allegedly dies in less than half a day without crurifragium.
 A crucifixion lasting only a few hours stands out not as normal but as an anomaly requiring explanation.
 
@@ -1164,7 +1164,7 @@ Finally, many scholars point out that the victim of crucifixion were always left
 However, even Philo of Alexandria, featured in many discussions in this book for unrelated reasons, described a case of numerous Jew insurrectionists in Alexandria in 38AD were actually taken down from the cross in exchange for a bribe.
 It is not completely clear from the text, but the more plausible reading is that some of the victims may have been taken down from the cross before they died.
 In this light it should not be considered as implausible that a member of the Sanhedrin would have been able to bargain with the centurion to convince Pilate Jesus already died.
-Josephus, \emph{Jewish War} 4.5.2 (333): He says he recognized three of his acquaintances being crucified, asked for their removal, and one of them survived.
+Josephus \cite[4.5.2]{josephus:war}: He says he recognized three of his acquaintances being crucified, asked for their removal, and one of them survived.
 Indications do not fully end at the burial, Thomas' request to touch wounds (John 20:27) only makes sense if the wounds are fresh and still healing---rather than glorified.
 
 The resurrection appearances recorded in the Gospels exhibit physical characteristics consistent with a wounded man in recovery rather than a supernatural apparition.

--- a/chapter3.tex
+++ b/chapter3.tex
@@ -3,7 +3,7 @@ Yet if he were only a claimant to the throne of Jerusalem, we would not see the 
 Jesus and his story must have been much more extraordinary than that.
 
 Royal pretenders attract their own nation; they do not instantly win foreigners.
-Judas the Galilean, described by Josephus (Ant. 18.1–10; War 2.117–118), led a rigorously Jewish resistance movement rooted in Israelite law and identity, and it produced no Greek following and no uptake beyond its own people.
+Judas the Galilean, described by Josephus \cite[18.1--10]{josephus:ant} \cite[2.117--118]{josephus:war}, led a rigorously Jewish resistance movement rooted in Israelite law and identity, and it produced no Greek following and no uptake beyond its own people.
 While we know Jesus had a connection to Jerusalem, many try to view his life and the early Christian movement purely through the lens of Second Temple Judaism or Jewish apocalypticism.
 But this lens is too narrow.
 The movement spoke Greek, wrote Greek, and framed Jesus in the political-religious idiom Greeks already used for rulers.
@@ -98,7 +98,7 @@ The Gospel of John likewise presents Jesus as the \emph{Logos}, the divine Word,
 Philo of Alexandria had already developed a theology of the Logos before the New Testament was written, and his influence is visible in both Johannine and Pauline language.
 
 Later Christian writers expressed the synthesis openly.
-Clement of Alexandria wrote: “God is one and the same, the universal Father, being known under many names.”
+Clement of Alexandria \cite{clement:stromata} wrote: "God is one and the same, the universal Father, being known under many names."
 Even popular piety reflected this blending.
 A Christian epitaph from the fifth century prays:
 “May the ruler of Olympus’ height
@@ -371,7 +371,7 @@ This is not a sermon; this is a priestly veto over the political mechanism by wh
 
 Josephus confirms the political core of the conflict by giving an entirely different explanation for John's death than the Gospel narrative, one that strips away narrative drama and exposes the state's real calculation.
 Because Josephus writes independently of Christian tradition, his political framing preserves an untheologized memory of how John was actually perceived.
-In Antiquities 18.116--119, Josephus describes John as a man of immense influence whose ability to persuade the crowds made Herod Antipas fear that John could ``lead them to do anything he wished,'' and the phrase is clearly meant to signal rebellion.
+In \cite[18.116--119]{josephus:ant}, Josephus describes John as a man of immense influence whose ability to persuade the crowds made Herod Antipas fear that John could ``lead them to do anything he wished,'' and the phrase is clearly meant to signal rebellion.
 Josephus says Antipas executed John ``to prevent any mischief he might cause,'' which in Herodian context means he eliminated a potential rival claimant before the rival could crystallize public support, and the execution is thus framed as a preventative strike in a volatile political environment.
 The contrast between Josephus and the Gospels is not a contradiction; it is two perspectives on the same event, one recording the theological flashpoint, the other recording the political threat.
 
@@ -495,7 +495,7 @@ But we should also note that tradition is by no means unique to Israel, and in f
 Notably, the Jewish Day of Atonement, where the sins of the people are taken away, refers to the quintessential Egyptian idea of the Book of the Dead and the Book of the Living.
 But while admittedly while the Jewish parallel here is possible, the Egyptian parallel is much more direct and explicit.
 Amun, the hidden father, was also portrayed as a ram or lamb.
-It is not a one-time vague reference, but a motif so widespread throughout the ancient world and many centuries that even Pliny the Elder noted it in his \emph{Natural History}.
+It is not a one-time vague reference, but a motif so widespread throughout the ancient world and many centuries that even Pliny the Elder noted it in his \cite{pliny:nh}.
 Alexander the Great was portrayed with the ram horns of Amun on his coins.
 And Amun was the one who forgave the sins of the people.
 During confession of sins in ancient Egypt, the following was said in the Hymn to Amun (Papyrus Leiden I 350 \emph{The Search for God in Ancient Egypt}):
@@ -652,9 +652,9 @@ Mary's elevation as heavenly queen continues that pattern of dynastic feminine p
 
 \paragraph{Mary as the New Eve.}
 Early Christian writers repeatedly name Mary as ``the new Eve''.
-Justin Martyr and Irenaeus both set up a deliberate contrast: as Eve's disobedience leads to death, Mary's assent leads to life.
+Justin Martyr \cite{justinmartyr:apology} and Irenaeus \cite{irenaeus:advhaer} both set up a deliberate contrast: as Eve's disobedience leads to death, Mary's assent leads to life.
 This is more than a moral inversion; it recasts the origin story of humanity around a new ancestral couple in which Mary is foundational.
-The \emph{Protoevangelium of James} deepens the pattern by portraying Mary as ``set apart for the Lord'' from infancy, raised in the Temple, and chosen as a uniquely pure bride.
+The \emph{Protoevangelium of James} \cite{protoevangelium} deepens the pattern by portraying Mary as ``set apart for the Lord'' from infancy, raised in the Temple, and chosen as a uniquely pure bride.
 The effect is to give Mary a mythic, archetypal status: she is not just the mother of one teacher but the starting point of a renewed human line and a renewed royal house.
 In Hellenistic terms, this is exactly how the founding ancestress of a dynasty is remembered and honored.
 
@@ -672,7 +672,7 @@ The lexica preserve this order: LSJ lists “kingship, dominion, monarchy” as 
 Thus when first-century hearers heard “\emph{basileia tou theou},” they thought not of a place but of the crown itself.
 
 The word was standard for the monarchies of the Hellenistic age---the Ptolemaic \emph{basileia}, the Seleucid \emph{basileia}, the Antigonid \emph{basileia}---as a matter of common speech, and in inscriptions these were praised as orders sanctioned by the gods.
-Philo of Alexandria could write in Greek that “the \emph{basileia} of God is the sovereignty over all things” (\emph{Spec. Leg}.~4.164), and Josephus records that Rome “granted the \emph{basileia} to Agrippa” (\emph{Ant}.~19.343), using the same word for the crown-right, not a map of land.
+Philo of Alexandria could write in Greek that "the \emph{basileia} of God is the sovereignty over all things" \cite[4.164]{philo:specleg}, and Josephus records that Rome "granted the \emph{basileia} to Agrippa" \cite[19.343]{josephus:ant}, using the same word for the crown-right, not a map of land.
 The Septuagint---the Greek translation of the Hebrew scriptures made for Greek-speaking Jews in Alexandria around 250 BC---likewise speaks of the God of heaven ``raising up a \emph{basileia} that shall never be destroyed'' (Dan LXX 2:44) and praises ``Your \emph{basileia} is a \emph{basileia} for all ages'' (Ps 145:13 LXX).
 This is the usage inherited by Jesus and his hearers.
 When he announced “the \emph{basileia} of God has drawn near” (Mark 1:15), they heard not a novel metaphor of piety but the familiar imperial claim of a crown restored by divine mandate.
@@ -755,7 +755,7 @@ Here the logic is explicit: ``for our sins'' (αἱ ἁμαρτίαι ἡμῶν
 The loss of political sovereignty is directly attributed to collective \textit{hamartia}, and the hope for restoration rests on divine intervention following national reformation.
 
 This same pattern appears in the Dead Sea Scrolls, in the prayers of the \textit{Community Rule} and the \textit{Damascus Document}, where the sectarians at Qumran frame Roman domination as God's punishment for the sins of the Jerusalem priesthood and the broader Jewish people.
-Josephus, writing after the catastrophic destruction of Jerusalem in 70 AD, interprets the Roman victory as God abandoning the rebels and punishing the nation for its transgressions (\textit{Jewish War} 5.19.4).
+Josephus, writing after the catastrophic destruction of Jerusalem in 70 AD, interprets the Roman victory as God abandoning the rebels and punishing the nation for its transgressions \cite[5.19.4]{josephus:war}.
 
 The Greek word ἁμαρτία (\textit{hamartia}), typically translated ``sin,'' carries this collective-political dimension throughout Hellenistic Greek literature.
 In classical Greek, \textit{hamartia} meant ``missing the mark'' or ``error,'' especially errors in judgment---Aristotle uses it in the \textit{Poetics} (1453a) for the tragic flaw or misjudgment that brings down a hero.

--- a/chapter4.tex
+++ b/chapter4.tex
@@ -460,7 +460,7 @@ Modern critical work by Eldon Epp, Michael Bird, and others has definitively sho
 This is a documented instance where a woman's apostolic status was obscured by later transmission.
 
 The same mechanism is visible within the Gospel of John itself.
-Elizabeth Schrader Polczer's article ``Was Martha of Bethany Added to the Fourth Gospel?'' (JBL 2017) demonstrates significant textual instability in the Mary/Martha passages of John 11--12.
+Elizabeth Schrader Polczer \cite{schrader:martha} demonstrates significant textual instability in the Mary/Martha passages of John 11--12.
 The data are striking: early manuscripts including P66 and P75 show the names ``Mary'' and ``Martha'' shifting positions, with ``Mary'' appearing where later manuscripts read ``Martha,'' or the two being swapped entirely.
 Some readings suggest that only one sister was originally present, named Mary, not Martha.
 Most significantly, the climactic confession in John 11:27---``Yes, Lord, I believe that you are the Christ, the Son of God, the one coming into the world''---may originally have been placed in the mouth of Mary, not Martha.
@@ -743,11 +743,11 @@ Therefore, the old assumption that “high Christology means late date” is inv
 It is widely acknowledged, though consistently understated, that the Fourth Gospel and the writings of Philo of Alexandria share the same theological air.
 Philo, active in the first half of the first century, systematized a doctrine of the \emph{Logos} that already anticipated much of what modern scholarship calls Johannine Christology.
 In his works the Logos is not a minor metaphor but the central mediator of divine sovereignty, described in a striking variety of roles:
-the divine blueprint and instrument of creation (\emph{De Opificio Mundi}~20, 146),
-the “first-born son” and “archangel” of God (\emph{De Confusione Linguarum}~146--147),
-the cosmic high priest interceding for creation (\emph{De Specialibus Legibus}~1.81; 4.123--125),
-the “image of God” and the “bond” holding the cosmos together (\emph{De Somniis}~1.215--239; \emph{De Cherubim}~35--36),
-and the guide and teacher of souls on pilgrimage (\emph{De Migratione Abrahami}~6).
+the divine blueprint and instrument of creation \cite[20, 146]{philo:opificio},
+the "first-born son" and "archangel" of God \cite[146--147]{philo:confusione},
+the cosmic high priest interceding for creation \cite[1.81; 4.123--125]{philo:specleg},
+the "image of God" and the "bond" holding the cosmos together \cite[1.215--239]{philo:somniis} \cite[35--36]{philo:cherubim},
+and the guide and teacher of souls on pilgrimage \cite[6]{philo:migratione}.
 He consistently attributes to the Logos sonship, mediation, illumination, priesthood, and indwelling presence---exactly the categories John employs in his Prologue and throughout his Gospel.
 
 The parallels are concrete and undeniable.
@@ -761,14 +761,14 @@ Later Johannine sayings (“I am the way, the truth, and the life,” 14:6) reso
 In short, virtually every key theme of the Johannine Prologue has a Philonic analogue.
 
 Modern scholars have wrestled with how to characterize this relationship.
-C.~H.~Dodd argued already that the Gospel of John draws heavily on the Logos-doctrine of Hellenistic Judaism, with Philo the clearest witness.
-Harold Attridge memorably described John and Philo as “two riffs on one Logos”: they share the same conceptual framework, with John’s unique note being incarnation.
-Peder Borgen pursued the parallels most fully, showing that John and Philo both read Exodus traditions---such as the manna and the tabernacle---through Logos-centered exegesis, making their overlap too specific to be coincidence.
-Raymond E.~Brown, though more cautious, conceded that Philo’s Logos provided one strand of the background, alongside Jewish \emph{Memra} and Wisdom traditions.
-David Runia has documented how later Christians freely drew on Philo, while stressing that direct dependence in John cannot be demonstrated beyond doubt.
-Daniel Boyarin offered a Jewish-centered explanation: John’s Prologue is intelligible as a midrash on the “Memra” within Second-Temple Judaism’s binitarian monotheism, with or without Philo.
-Yet this very point confirms Philo’s significance, since his writings show that such a “high Christology” was already part of Alexandrian Judaism.
-Marian Hillar pressed this to its conclusion: Philo’s Logos-theology is itself already Christological, anticipating the categories John later applies to Jesus.
+C.~H.~Dodd \cite{dodd:fourthgospel} argued already that the Gospel of John draws heavily on the Logos-doctrine of Hellenistic Judaism, with Philo the clearest witness.
+Harold Attridge \cite{attridge:essays} memorably described John and Philo as "two riffs on one Logos": they share the same conceptual framework, with John's unique note being incarnation.
+Peder Borgen \cite{borgen:philo} pursued the parallels most fully, showing that John and Philo both read Exodus traditions---such as the manna and the tabernacle---through Logos-centered exegesis, making their overlap too specific to be coincidence.
+Raymond E.~Brown \cite{brown:johannine}, though more cautious, conceded that Philo's Logos provided one strand of the background, alongside Jewish \emph{Memra} and Wisdom traditions.
+David Runia \cite{runia:philo} has documented how later Christians freely drew on Philo, while stressing that direct dependence in John cannot be demonstrated beyond doubt.
+Daniel Boyarin \cite{boyarin:jewishgospels} offered a Jewish-centered explanation: John's Prologue is intelligible as a midrash on the "Memra" within Second-Temple Judaism's binitarian monotheism, with or without Philo.
+Yet this very point confirms Philo's significance, since his writings show that such a "high Christology" was already part of Alexandrian Judaism.
+Marian Hillar \cite{hillar:logos} pressed this to its conclusion: Philo's Logos-theology is itself already Christological, anticipating the categories John later applies to Jesus.
 
 The cumulative effect is stark.
 What John proclaims in the Prologue---that the divine Logos, long confessed as Son, Light, Mediator, and High Priest, has now taken flesh---is not a sudden innovation.
@@ -1200,12 +1200,12 @@ These are not the same story as the Gospels, but they teach the same kingship ru
 The most \emph{precise} narrative parallel is Siddhartha Gautama’s trial under the Bodhi tree: Māra offers (1) sensual desire, (2) a terrifying challenge demanding miraculous proof of survival, and (3) sovereignty over the world, as related in the \emph{Lalitavistara} (ch.~24) and the \emph{Nidānakathā}.
 The structural match to the Gospel’s triad of \emph{bread-spectacle-kingdoms} is striking.
 Zarathustra’s confrontation with Angra Mainyu likewise unfolds as a triad: (1) riches and wealth, (2) women and pleasure, and (3) kingship and power; he refuses each in fidelity to \emph{asha} (truth/order), as preserved in the \emph{Vendīdād}~19 and the \emph{Dēnkard}~7.
-Greek moral pedagogy offers the Heraclean template, especially in Prodicus’ parable transmitted by Xenophon (\emph{Mem}.~2.1), where the royal hero must choose the hard path of virtue over the easy path of vice.
+Greek moral pedagogy offers the Heraclean template, especially in Prodicus' parable transmitted by Xenophon \cite[2.1]{xenophon:memorabilia}, where the royal hero must choose the hard path of virtue over the easy path of vice.
 The forms differ, but the threshold logic is constant: pre-eminence requires a decisive rejection of appetite, display, and domination.
 
 \paragraph*{Hellenistic and Persian accession practice.}
 Historical kings also meet ordeals just \emph{before} enthronement.
-Cyrus is recognized through proved nobility after humble upbringing (Herodotus~1.114--122; Xenophon, \emph{Cyropaedia}).
+Cyrus is recognized through proved nobility after humble upbringing \cite[1.114--122]{herodotus:histories} \cite{xenophon:cyropaedia}.
 Darius~I casts his first year in the Behistun inscription as defeating rival claimants to secure the crown.
 Alexander seeks divine sanction at Delphi and Siwa before world conquest.
 These are military-political and oracular trials rather than temptations, but the timing is the same: a testing immediately prior to rule.
@@ -1259,7 +1259,7 @@ If we accept that the gospel of Luke was written as a correspondence with the au
 
 \subsection{The Gospel of Marcion deserves another look in this context.}\label{subsec:the-gospel-of-marcion-deserves-another-look-in-this-context.}
 
-The gospel associated with Marcion (c. 140AD) survives only through hostile witnesses such as Tertullian (*Adversus Marcionem*, c. 207AD), Epiphanius (*Panarion*, c. 374AD), and the *Dialogue of Adamantius* (late 3rd/early 4th century).
+The gospel associated with Marcion (c. 140AD) survives only through hostile witnesses such as Tertullian \cite{tertullian:marcionem}, Epiphanius \cite{epiphanius:panarion}, and the \emph{Dialogue of Adamantius} (late 3rd/early 4th century).
 Despite polemical framing, these sources preserve enough data to reconstruct key features of Marcion’s gospel.
 It opened at Luke 3:1 (“In the fifteenth year of Tiberius”), contained no infancy narratives, omitted any clear prophecy of the 70AD temple destruction, and consistently presented simpler readings than the canonical Luke.
 

--- a/chapter5.tex
+++ b/chapter5.tex
@@ -468,9 +468,9 @@ If there was no organized persecution of Christians, it is hard to explain why b
 
 In the Roman world, military metaphors were never just metaphors.
 Roman writers used soldier-language for groups that took oaths, had secret loyalties, maintained internal discipline, and operated in cells or brotherhoods.
-Cicero calls Catiline's conspirators ``soldiers of Catiline'' long after they were unarmed (\emph{Philippics} 13.27).
-Josephus describes followers of Judas the Galilean as ``disciplined like soldiers'' even though they were not a formal army (\emph{Antiquities} 18.23).
-Plutarch describes political factions as acting ``like soldiers,'' even without weapons (\emph{Life of Sertorius} 26).
+Cicero calls Catiline's conspirators ``soldiers of Catiline'' long after they were unarmed \cite[13.27]{cicero:philippics}.
+Josephus describes followers of Judas the Galilean as ``disciplined like soldiers'' even though they were not a formal army \cite[18.23]{josephus:ant}.
+Plutarch describes political factions as acting ``like soldiers,'' even without weapons \cite[Life of Sertorius 26]{plutarch:lives}.
 Whenever a movement was oath-bound or aimed at regime change, Roman authors defaulted to soldier-language even when no open army existed.
 
 Paul uses this vocabulary extensively: στρατιώτης Χριστοῦ, ``soldier of Christ'' (2 Tim 2:3); συστρατιώτης, ``fellow-soldier'' (Phil 2:25; Phlm 2); στρατεία, ``military campaign'' (1 Cor 9:7; 2 Cor 10:3--4); πανοπλία, ``full armor'' (Eph 6:11).
@@ -639,9 +639,9 @@ No alternative apostolic names are recorded for them.
 
 \subsection{Patristic attestations (authorship in antiquity).}
 Before the mid-third century the picture is consistent.
-\textbf{Papias} (via Eusebius, \textit{Hist.\ Eccl.} 3.39) --- Mark wrote as Peter’s interpreter.
+\textbf{Papias} (via Eusebius \cite[3.39]{eusebius:he}) --- Mark wrote as Peter's interpreter.
 Matthew compiled the \textit{logia}.
-\textbf{Irenaeus} (\textit{Adv.\ Haer.} 3.1.1) --- explicitly lists and defends the four: Matthew, Mark, Luke (Paul’s companion), John.
+\textbf{Irenaeus} \cite[3.1.1]{irenaeus:advhaer} --- explicitly lists and defends the four: Matthew, Mark, Luke (Paul's companion), John.
 The \textbf{Muratorian Fragment} (late 2nd c.) names Luke and John as the third and fourth gospels and recognizes a Pauline corpus.
 \textbf{Clement of Alexandria} and \textbf{Origen} repeat these attributions.
 \textbf{Eusebius} later summarizes them as received.
@@ -797,16 +797,16 @@ They stand in ordered opposition to Rome's Beast, just as the Kingdom of God sta
 Revelation stages a clash of empires, not a retreat into abstraction.
 
 By the end of the second century Irenaeus makes this grammar explicit and canonical.
-In \textit{Against Heresies} 3.11.8 he takes the living creatures of Revelation 4:7 and reads them as figures of the whole ``economy'' of the Son of God, then states flatly that ``the living creatures are quadriform, and the Gospel is quadriform, and the course followed by the Lord is quadriform.''
+In \cite[3.11.8]{irenaeus:advhaer} he takes the living creatures of Revelation 4:7 and reads them as figures of the whole ``economy'' of the Son of God, then states flatly that ``the living creatures are quadriform, and the Gospel is quadriform, and the course followed by the Lord is quadriform.''
 For Irenaeus the point is not a cute allegory but a necessity: the Church is spread to the four winds, the world has four zones and four principal winds, and therefore the one Christ must be witnessed in a fourfold way if the proclamation is to match the structure of creation.
 
 Third-century writers reinforce this logic.
 Origen, in his homilies on Ezekiel and Luke, treats the number four as intrinsic to the Gospel tradition, tying it to the four rivers of Eden, the four winds, and the four corners of the earth, and simply assumes that Ezekiel's and John's creatures provide the basic schema for how the one Christ can be presented in multiple, non-competing forms.
-Victorinus of Pettau, the earliest surviving commentator on Revelation, is even more blunt: commenting on Revelation 4 he writes, ``The four living creatures are the four Gospels,'' and assigns each creature to one evangelist while insisting that together they surround the throne and sing the Trisagion.
+Victorinus of Pettau \cite{victorinus:apocalypse}, the earliest surviving commentator on Revelation, is even more blunt: commenting on Revelation 4 he writes, ``The four living creatures are the four Gospels,'' and assigns each creature to one evangelist while insisting that together they surround the throne and sing the Trisagion.
 By this stage the identification is fixed: whenever orthodox Christians read Revelation's throne, they saw the canonical fourfold Gospel radiating from it.
 
 Fourth- and fifth-century Latin theology takes this over and builds orthodoxy upon it.
-Augustine devotes an entire chapter in \textit{De Consensu Evangelistarum} to ``the four living creatures in the Apocalypse, which have been taken as apt figures of the four evangelists,'' accepts the identification as obvious, and only debates which creature best fits which evangelist.
+Augustine devotes an entire chapter in \cite{augustine:consensu} to ``the four living creatures in the Apocalypse, which have been taken as apt figures of the four evangelists,'' accepts the identification as obvious, and only debates which creature best fits which evangelist.
 For Augustine the tetramorph means that the evangelists differ and yet agree, just as four faces can belong to one throne-chariot: the structure of four is not an accident of manuscript survival but a sign that the Spirit has distributed one Christological reality into four complementary perspectives.
 Jerome, in his prefaces and commentary on Matthew, standardizes the now-familiar Western assignment---man for Matthew, lion for Mark, ox for Luke, eagle for John---and welds it to his Vulgate ordering, which dominates medieval art and liturgy.
 Later Latin writers like Chromatius and Rabanus Maurus simply repeat the pattern: four living creatures, four winds, four corners of the earth, four evangelists, one throne.
@@ -892,7 +892,7 @@ Taken together, the manuscript counts, text clustering, and codex structures sho
 P\textsuperscript{52}, the Rylands fragment of John 18, is conventionally dated to c.~125--175.
 This dating is constrained by the assumption that the Gospel of John was composed c.~100--110.
 Paleography alone permits a late first--early second century date for P\textsuperscript{52}.
-The lower bound of the standard dating is imposed externally by theological assumptions rather than by the handwriting itself, as demonstrated by Brent Nongbri.
+The lower bound of the standard dating is imposed externally by theological assumptions rather than by the handwriting itself, as demonstrated by Brent Nongbri \cite{nongbri:p52}.
 The same circular reasoning governs the conventional dating of Papias of Hierapolis, who is commonly placed c.~120 despite the absence of any explicit ancient date.
 Papias's chronology is inferred entirely from later witnesses, chiefly Irenaeus of Lyons and Eusebius of Caesarea, rather than from independent historical anchors.
 The date drifts later because scholars assume late gospel composition, and once that assumption is relaxed Papias fits naturally within the late first century.
@@ -917,9 +917,9 @@ P\textsuperscript{66} and P\textsuperscript{75} (John) and P\textsuperscript{9} 
 The Muratorian Fragment includes Johannine Catholic epistles.
 John writes in the intellectual Greek of Alexandria, the greatest philosophical center of the eastern Mediterranean.
 His opening word \textit{Logos} uses the exact metaphysical sense found in Philo of Alexandria's treatises such as \textit{De Opificio Mundi} 6--25, where the Logos is the divine rational structure ordering the cosmos.
-The term \textit{monogenēs} in John 1:14 and 1:18 mirrors Philo's use in \textit{De Sacrificiis} 41 for the unique heavenly image, showing that the author shared Alexandrian philosophical vocabulary rather than Palestinian synagogue Greek.
-John's pairing of \textit{charis} and \textit{alētheia} (John 1:14) matches the same Alexandrian combination in \textit{Leg. All.} 3.207, where Philo describes divine attributes in Greek conceptual terms unknown in Judea.
-His light-darkness dualism (\textit{phōs}/\textit{skotos}) belongs to Alexandrian Middle Platonism, a style seen in Philo's \textit{Quis Rer. Div. Heres Sit} 87--88 and not in Judean legal literature.
+The term \textit{monogenēs} in John 1:14 and 1:18 mirrors Philo's use in \cite[41]{philo:sacrificiis} for the unique heavenly image, showing that the author shared Alexandrian philosophical vocabulary rather than Palestinian synagogue Greek.
+John's pairing of \textit{charis} and \textit{alētheia} (John 1:14) matches the same Alexandrian combination in \cite[3.207]{philo:legall}, where Philo describes divine attributes in Greek conceptual terms unknown in Judea.
+His light-darkness dualism (\textit{phōs}/\textit{skotos}) belongs to Alexandrian Middle Platonism, a style seen in Philo \cite[87--88]{philo:heres} and not in Judean legal literature.
 This vocabulary shows that John's Greek grew out of an Alexandrian philosophical world in which scripture was interpreted through Platonic categories, not rabbinic ones.
 The earliest material witnesses to John---P\textsuperscript{66} and P\textsuperscript{75}---come from Egypt and display the spelling patterns of Egyptian scribal schools in the Bodmer collection.
 The physical papyri, the philosophical language, and the conceptual framework all point to an Alexandrian environment where Greek metaphysics and Jewish scripture had been fused for centuries.

--- a/chapter6.tex
+++ b/chapter6.tex
@@ -28,7 +28,7 @@ This is the only one of its kind and lives five hundred years.
 When the time of its dissolution draws near, it makes for itself a coffin of frankincense and myrrh and other spices, and when the time is fulfilled it enters it and dies.
 But as its flesh decays, a worm is produced, which is nourished by the moisture of the dead creature and puts forth wings.
 Then, when it has grown strong, it takes up that coffin and flies from the land of Arabia to Egypt, to the city of Heliopolis, and, in the daytime, in the sight of all, it places itself on the altar of the sun.
-(\emph{1 Clement} 25:1--5)
+\cite[25:1--5]{clement:firstclement}
 \end{quote}
 
 Modern scholarship almost invariably interprets this passage as an allegory of Christ's resurrection and of the general resurrection of the dead.
@@ -55,14 +55,14 @@ Seen against this background, the passage is at minimum an appropriation, and ar
 The sign of imperial eternity is re-told with an Eastern itinerary and relocated sacrifice.
 
 Clement of Alexandria, writing around 190 AD, knows the same complex of ideas and makes the imperial coloring explicit.
-In his \emph{Stromata} he describes the phoenix as \emph{porphyrous} (πορφυροῦς), ``purple,'' the same adjective used for imperial cloaks and royal textiles.
+In his \cite{clement:stromata} he describes the phoenix as \emph{porphyrous} (πορφυροῦς), ``purple,'' the same adjective used for imperial cloaks and royal textiles.
 In Greek usage both πορφυροῦς and related terms like φοῖνιξ mark the deep red-purple associated with high status and royal rank.
 Christian martyr literature picks up exactly this language in phrases like ``the purple of blood'' (τὸ πορφυροῦν αἷμα), describing the martyr's blood as a kind of royal dye.
 The phoenix, purple with royal plumage, and the martyr, clothed in the purple of blood, are drawn into the same semantic field of suffering, sovereignty, and cosmic renewal.
 
 By the early third century the phoenix has become a standard Christian emblem of resurrection in both literature and art, but the imperial undertones remain.
-Tertullian, in \emph{On the Resurrection of the Flesh} 13, repeats the story of the phoenix as a natural proof that bodies can die and rise again, explicitly treating it as a sign for ``the resurrection of our bodies.''
-Around the same time or slightly later, the Latin poem \emph{De ave phoenix}, generally attributed to Lactantius, elaborates the phoenix's thousand-year life, fiery death, and rebirth in a paradisical Eastern garden; while not overtly Christian, it was quickly read as an allegory of Christ's resurrection and of the paradisal homeland of the redeemed.
+Tertullian, in \cite[13]{tertullian:resurrection}, repeats the story of the phoenix as a natural proof that bodies can die and rise again, explicitly treating it as a sign for ``the resurrection of our bodies.''
+Around the same time or slightly later, the Latin poem \cite{lactantius:phoenix}, generally attributed to Lactantius, elaborates the phoenix's thousand-year life, fiery death, and rebirth in a paradisical Eastern garden; while not overtly Christian, it was quickly read as an allegory of Christ's resurrection and of the paradisal homeland of the redeemed.
 Phoenix-type resurrection imagery---typically a bird perched on a palm branch---appears in third-century funerary art, including the Catacomb of Priscilla (Greek Chapel complex), as a visual shorthand for eternal life.
 Medieval descriptions of the Old St Peter's apse mosaic (attested in the \emph{Liber Pontificalis} tradition and the notes of Giacomo Grimaldi before the Renaissance rebuilding) describe a bird above the cross and tree-of-life motif, widely interpreted by art historians as a phoenix, visually transferring imperial ``eternity'' language into a Christological key.
 
@@ -175,9 +175,9 @@ It is not remotely plausible that this single event, in a city where almost none
 What we need to realize is that the destruction of the Temple in Jerusalem was only one of many violent events that marked the same decade.
 The late 60s and early 70s AD were a time of massive instability across the Greek East of the Roman Empire.
 In Galilee, Josephus fought the Romans as commander of the northern army in the \textit{First Jewish--Roman War} (66--73 AD).
-At the same time, a fierce \textbf{Greek--Jewish civil war} broke out in Alexandria in 66 AD, when the Greek and Jewish quarters of the city erupted into mutual slaughter; the legions sent by Vespasian to restore order eventually razed much of the city (Josephus, \textit{War} 2.497--507; Philo, \textit{In Flaccum}).
-Similar \textbf{inter-ethnic riots} followed in Antioch and Damascus, where Greek and Jewish citizens massacred each other in the thousands (Josephus, \textit{War} 7.43--45).
-Meanwhile, in Ephesus, Sardis, and throughout Asia Minor, there were \textbf{anti-Roman uprisings} over taxation and forced conscription, recorded by Tacitus (\textit{Histories} 2.81) and Dio Cassius.
+At the same time, a fierce \textbf{Greek--Jewish civil war} broke out in Alexandria in 66 AD, when the Greek and Jewish quarters of the city erupted into mutual slaughter; the legions sent by Vespasian to restore order eventually razed much of the city \cite[2.497--507]{josephus:war} \cite{philo:flaccum}.
+Similar \textbf{inter-ethnic riots} followed in Antioch and Damascus, where Greek and Jewish citizens massacred each other in the thousands \cite[7.43--45]{josephus:war}.
+Meanwhile, in Ephesus, Sardis, and throughout Asia Minor, there were \textbf{anti-Roman uprisings} over taxation and forced conscription, recorded by Tacitus \cite[2.81]{tacitus:histories} and Dio Cassius.
 In Cyrene and Egypt, the \textbf{Kitos War} (beginning around 70 AD and flaring up again under Trajan) continued the same unrest.
 That is essentially every major Greek city in the Roman Empire, all in revolt against Roman rule, all at the same time.
 Even in Rome itself, several senators and equestrians were accused of complicity with eastern rebels and executed for treason.
@@ -185,7 +185,7 @@ This was not an isolated Jewish war---it was a general Greek and oriental rebell
 
 The Roman high command itself saw these revolts as one system.
 A preserved Tacitean tradition in Sulpicius Severus describes Titus' war council debating whether to spare or destroy the Temple.
-Titus ultimately orders its destruction ``so that the religion of the Jews and of the Christians might be more completely overthrown,'' for both movements ``sprang from the same source, and if the root were destroyed, the branch would perish'' (Sulpicius Severus, \textit{Chronica} 2.30.6--7).
+Titus ultimately orders its destruction ``so that the religion of the Jews and of the Christians might be more completely overthrown,'' for both movements ``sprang from the same source, and if the root were destroyed, the branch would perish'' \cite[2.30.6--7]{sulpicius:chronica}.
 This is not theology.
 This is a Roman war document identifying Jews and the people who later acquire the name ``Christians'' as one political-religious bloc whose power rested on the same Jerusalem center.
 
@@ -290,7 +290,7 @@ Note the shields only signified the Christos on them and not Jesus directly, whi
 If the war was thought for religious reasons primarily, there would have likely been a lot more emphasis on the cross and mass conversions to Christianity, and we do not see that being strongly emphasized in the historical records of this particular war.
 We do however see the large emphasis on political changes and restoring the rule in the East.
 Constantine's use of Chi-Rho on coins, shields, and banners was not a personal devotion to Jesus of Nazareth, but the creation of a Christic imperial monogram---a sign that the empire itself now belonged to the Christos, the anointed ruler.
-Eusebius (\emph{Life of Constantine}, Book 1) insists that the empire was renewed under the Christ, making it clear that Christianity functioned as the legitimizing religion of a new imperial order.
+Eusebius \cite[Book 1]{eusebius:vita} insists that the empire was renewed under the Christ, making it clear that Christianity functioned as the legitimizing religion of a new imperial order.
 
 The timing is critical: Rome's Christianization coincided precisely with the division of the empire into Western and Eastern halves.
 The restoration of the Eastern Roman Empire was the explicit goal of this movement, and Eusebius's writings confirm it.
@@ -326,10 +326,10 @@ The promise is not escape to heaven but the replacement of Roman imperium with d
 \section{Origen of Alexandria (c.~185--254 AD): Universal Kingdom Through the Logos}\label{sec:origen-universal-kingdom}
 
 Origen, writing from Alexandria---the intellectual center of the Greek East---articulated a vision of cosmic restoration through the Logos that merges Greek philosophy with Christian eschatology.
-In \emph{Contra Celsum}, he explicitly defends Christianity against accusations of sedition by arguing that Christians seek not the overthrow of Rome by force but its transformation through divine truth.
+In \cite{origen:contracels}, he explicitly defends Christianity against accusations of sedition by arguing that Christians seek not the overthrow of Rome by force but its transformation through divine truth.
 But transformation toward what end?
 
-Origen writes in \emph{Contra Celsum} 8.68:
+Origen writes in \cite[8.68]{origen:contracels}:
 
 \begin{quote}
 We do say that there will eventually be, when the Word has prevailed over the entire rational creation and has converted every soul to His perfection, a time when He shall deliver up the kingdom to God the Father, when all rational beings shall have been moulded by the Word of God into one perfection.
@@ -340,15 +340,15 @@ Origen envisions a time when ``the Word has prevailed over the entire rational c
 The ``kingdom'' that Christ will ``deliver up to God the Father'' is a political reality: the universal kingdom unified under divine rule.
 
 Origen's concept of \emph{apokatastasis} (ἀποκατάστασις)---the restoration of all things---is often spiritualized by modern interpreters, but his language is explicitly political.
-He describes the eventual submission of all \emph{archontes} (ἄρχοντες, rulers) and \emph{exousiai} (ἐξουσίαι, authorities) to Christ (\emph{De Principiis} 3.6.6), using the vocabulary of imperial administration.
+He describes the eventual submission of all \emph{archontes} (ἄρχοντες, rulers) and \emph{exousiai} (ἐξουσίαι, authorities) to Christ \cite[3.6.6]{origen:principiis}, using the vocabulary of imperial administration.
 This is restoration theology: the reconstitution of a divinely ordered political cosmos, centered in the Greek-speaking East where Origen wrote.
 
 \section{Irenaeus of Lyons (c.~130--202 AD): Providence and the Coming Kingdom}\label{sec:irenaeus-providence-kingdom}
 
-Irenaeus, bishop of Lyons (a Greek-speaking city in Gaul), articulates a millennialist eschatology in \emph{Against Heresies} that envisions a literal earthly kingdom ruled by Christ.
+Irenaeus, bishop of Lyons (a Greek-speaking city in Gaul), articulates a millennialist eschatology in \cite{irenaeus:advhaer} that envisions a literal earthly kingdom ruled by Christ.
 Writing around 180 AD, Irenaeus interprets Daniel's vision of four kingdoms (Dan 2:31-45) as prophecy of the succession of empires---Babylonian, Median, Persian, and finally the Roman Empire---with the kingdom of God as the fifth and final kingdom that will crush and replace all earthly powers.
 
-In \emph{Against Heresies} 5.26.1, Irenaeus writes:
+In \cite[5.26.1]{irenaeus:advhaer}, Irenaeus writes:
 
 \begin{quote}
 In the end, the stone cut without hands [from Daniel] shall smite the image upon the iron and clay feet and shall break them to pieces, and shall itself fill the whole earth.
@@ -357,18 +357,18 @@ This refers to the kingdom of our Lord...which shall break in pieces and bring t
 
 This is not spiritual allegory---it is explicit political prophecy.
 The ``stone'' that smites the feet of iron and clay (Rome) is the kingdom of Christ, which will physically ``fill the whole earth'' and ``break in pieces...all kingdoms.''
-Irenaeus interprets this as the establishment of a millennial kingdom on earth where the risen saints will reign with Christ (5.32.1--5.35.2), directly paralleling Revelation 20:4-6.
+Irenaeus interprets this as the establishment of a millennial kingdom on earth where the risen saints will reign with Christ \cite[5.32.1--5.35.2]{irenaeus:advhaer}, directly paralleling Revelation 20:4-6.
 
 Crucially, Irenaeus's vision is geographically centered: the kingdom will be restored in Jerusalem and the surrounding lands, but Jerusalem here functions as the symbolic capital of the renewed oikoumene---the civilized world now under divine rule, not Roman imperium.
 
 \section{Tertullian (c.~155--240 AD)}\label{sec:tertullian-c.-155240-ad---in-his-writings-such-as-apology-and-on-the-resurrection-of-the-flesh-tertullian-often-implies-the-eventual-triumph-of-christianity-within-the-roman-empire-framing-it-as-part-of-a-divine-plan.-while-he-doesnt-directly-speak-of-the-restoration-of-the-empire-there-is-a-sense-of-christianity-fulfilling-the-destiny-of-the-roman-state.}
 
-In his writings, such as \emph{Apology} and \emph{On the Resurrection of the Flesh}, Tertullian often implies the eventual triumph of Christianity within the Roman Empire, framing it as part of a divine plan.
+In his writings, such as \cite{tertullian:apology} and \cite{tertullian:resurrection}, Tertullian often implies the eventual triumph of Christianity within the Roman Empire, framing it as part of a divine plan.
 While he doesn't directly speak of the ``restoration'' of the empire, there is a sense of Christianity fulfilling the destiny of the Roman state.
 
 \section{Eusebius of Caesarea (c.~260--340 AD)}\label{sec:eusebius-of-caesarea-c.-260340-ad}
 
-In his work \emph{Ecclesiastical History} and \emph{Life of Constantine}, Eusebius explicitly presents the rise of Constantine and the establishment of Christianity as the fulfillment of God's plan for the Roman Empire.
+In his work \cite{eusebius:he} and \cite{eusebius:vita}, Eusebius explicitly presents the rise of Constantine and the establishment of Christianity as the fulfillment of God's plan for the Roman Empire.
 He sees Constantine's reign as a ``restoration'' of the empire, aligning it with divine will.
 This reflects the idea that Christianity would not only restore the empire but also bring it to its true, Christian purpose.
 
@@ -379,14 +379,14 @@ He often frames the Christian emperor as the rightful ruler under divine guidanc
 
 \section{Victorinus of Pettau (c.~250--303 AD)}\label{sec:victorinus-of-pettau-c.-250303-ad}
 
-In his \emph{Commentary on the Apocalypse}, Victorinus draws connections between the Roman Empire and the eventual triumph of Christianity.
+In his \cite{victorinus:apocalypse}, Victorinus draws connections between the Roman Empire and the eventual triumph of Christianity.
 Like many of his contemporaries, he believes that the empire is part of God's plan and that its ultimate transformation into a Christian empire would bring about the fulfillment of prophecy.
 This can be seen as a form of ``restoration'' through the christianization of the empire.
 
 \section{The revolt is not militaristic---Rome chose to spiritually convert to Christianity, and the Eastern Roman Empire was restored peacefully while the Christian writers started to praise Rome.}\label{sec:the-revolt-is-not-militaristic-rome-chose-to-spiritually-convert-to-christianity-and-the-eastern-roman-empire-was-restored-peacefully-while-the-christian-writers-started-to-praise-rome.}
 
-Lactantius, writing shortly before Constantine’s victory, declared in \emph{Divine Institutes} that Rome’s destiny was to become Christian, and that the empire itself was God’s instrument to unify the world.
-Augustine of Hippo (354--430 AD)---Expanded In \emph{City of God}, Augustine offers a vision where the fall of the Roman Empire is viewed through a Christian lens.
+Lactantius, writing shortly before Constantine's victory, declared in \cite{lactantius:institutes} that Rome's destiny was to become Christian, and that the empire itself was God’s instrument to unify the world.
+Augustine of Hippo (354--430 AD)---Expanded In \cite{augustine:civdei}, Augustine offers a vision where the fall of the Roman Empire is viewed through a Christian lens.
 He argues that the decline of the empire does not indicate the failure of divine providence.
 While he focuses on the spiritual aspects of empire, he acknowledges the empire's role in preparing the world for the Christian kingdom, suggesting a ``restoration'' of the Roman Empire as a Christian entity in the future.
 
@@ -401,7 +401,7 @@ But the political reading reveals why it resonated so powerfully with Greek-spea
 
 \subsection{The Vision of the Old Woman Transformed: Restoration of Greek Vigor}
 
-The central vision of \emph{Hermas} (Vision 1--4) features an old woman who progressively becomes younger.
+The central vision of \emph{Hermas} \cite[Vision 1--4]{shepherd:hermas} features an old woman who progressively becomes younger.
 In the first vision, she appears elderly, seated in a chair, holding a book.
 In subsequent visions, she grows younger, her face more vigorous, until in the fourth vision she appears as a radiant bride.
 Hermas asks the Shepherd who this woman is, and the answer given is: ``the Church.''
@@ -429,7 +429,7 @@ This is the exact narrative arc of occupied peoples' literature: loss, resistanc
 
 \subsection{The Tower Vision: Rebuilding the Greek Oikoumene}
 
-The most sustained allegory in \emph{Hermas} is the vision of the tower being built (Vision 3, Similitude 9).
+The most sustained allegory in \emph{Hermas} \cite[Vision 3, Similitude 9]{shepherd:hermas} is the vision of the tower being built.
 The tower is constructed of stones, some of which are rejected, some of which require shaping and purification before they can be fitted into the structure.
 The tower represents ``the Church,'' but the architectural imagery is unmistakably Greek: the tower (\emph{pyrgos}, πύργος) built of carefully fitted stones (\emph{lithoi}, λίθοι) echoes the monumental architecture of Hellenistic city-building.
 

--- a/references.bib
+++ b/references.bib
@@ -191,6 +191,38 @@
   keywords     = {ancient},
 }
 
+@book{philo:confusione,
+  author       = {Philo of Alexandria},
+  title        = {De Confusione Linguarum},
+  origlanguage = {greek},
+  note         = {Written c.~first century AD},
+  keywords     = {ancient},
+}
+
+@book{philo:migratione,
+  author       = {Philo of Alexandria},
+  title        = {De Migratione Abrahami},
+  origlanguage = {greek},
+  note         = {Written c.~first century AD},
+  keywords     = {ancient},
+}
+
+@book{epiphanius:mensuris,
+  author       = {Epiphanius of Salamis},
+  title        = {De Mensuris et Ponderibus},
+  origlanguage = {greek},
+  note         = {Written c.~392 AD},
+  keywords     = {patristic},
+}
+
+@book{polybius:histories,
+  author       = {Polybius},
+  title        = {Histories},
+  origlanguage = {greek},
+  note         = {Written c.~second century BC},
+  keywords     = {ancient},
+}
+
 % -----------------------------------------------------------------------------
 %  CHURCH FATHERS AND EARLY CHRISTIAN LITERATURE  (keyword = patristic)
 % -----------------------------------------------------------------------------
@@ -532,6 +564,60 @@
   keywords  = {modern},
 }
 
+@book{protoevangelium,
+  author       = {{Anonymous}},
+  title        = {Protoevangelium of James},
+  origlanguage = {greek},
+  note         = {Written c.~mid-second century AD},
+  keywords     = {patristic},
+}
+
+@book{dodd:fourthgospel,
+  author    = {Dodd, C. H.},
+  title     = {The Interpretation of the Fourth Gospel},
+  publisher = {Cambridge University Press},
+  location  = {Cambridge},
+  year      = {1953},
+  keywords  = {modern},
+}
+
+@book{borgen:philo,
+  author    = {Borgen, Peder},
+  title     = {Philo, John, and Paul},
+  subtitle  = {New Perspectives on Judaism and Early Christianity},
+  publisher = {Scholars Press},
+  location  = {Atlanta},
+  year      = {1987},
+  keywords  = {modern},
+}
+
+@book{boyarin:jewishgospels,
+  author    = {Boyarin, Daniel},
+  title     = {The Jewish Gospels},
+  subtitle  = {The Story of the Jewish Christ},
+  publisher = {The New Press},
+  location  = {New York},
+  year      = {2012},
+  keywords  = {modern},
+}
+
+@book{runia:philo,
+  author    = {Runia, David T.},
+  title     = {Philo in Early Christian Literature},
+  publisher = {Van Gorcum},
+  location  = {Assen},
+  year      = {1993},
+  keywords  = {modern},
+}
+
+@article{schrader:martha,
+  author    = {Schrader Polczer, Elizabeth},
+  title     = {Was Martha of Bethany Added to the Fourth Gospel in the Second Century?},
+  journal   = {Harvard Theological Review},
+  year      = {2017},
+  keywords  = {modern},
+}
+
 @book{deboer:magdalene,
   author    = {de Boer, Esther A.},
   title     = {The Gospel of Mary},
@@ -539,5 +625,121 @@
   publisher = {T\&T Clark},
   location  = {London},
   year      = {2004},
+  keywords  = {modern},
+}
+
+% --- Additional ancient sources ---
+
+@book{quintilian:declamation,
+  author       = {Quintilian},
+  title        = {Declamationes},
+  origlanguage = {latin},
+  note         = {Attributed to Quintilian, c.~first century AD},
+  keywords     = {ancient},
+}
+
+@book{herodotus:histories,
+  author       = {Herodotus},
+  title        = {Histories},
+  origlanguage = {greek},
+  note         = {Written c.~fifth century BC},
+  keywords     = {ancient},
+}
+
+@book{xenophon:cyropaedia,
+  author       = {Xenophon},
+  title        = {Cyropaedia},
+  origlanguage = {greek},
+  note         = {Written c.~370s BC},
+  keywords     = {ancient},
+}
+
+@book{philo:legall,
+  author       = {Philo of Alexandria},
+  title        = {Legum Allegoriarum},
+  origlanguage = {greek},
+  note         = {Written c.~first century AD},
+  keywords     = {ancient},
+}
+
+@book{philo:heres,
+  author       = {Philo of Alexandria},
+  title        = {Quis Rerum Divinarum Heres Sit},
+  origlanguage = {greek},
+  note         = {Written c.~first century AD},
+  keywords     = {ancient},
+}
+
+% --- Additional patristic sources ---
+
+@book{lactantius:phoenix,
+  author       = {Lactantius},
+  title        = {De ave phoenix},
+  origlanguage = {latin},
+  note         = {Written c.~early fourth century AD},
+  keywords     = {patristic},
+}
+
+@book{lactantius:institutes,
+  author       = {Lactantius},
+  title        = {Divinae Institutiones},
+  origlanguage = {latin},
+  note         = {Written c.~303--311 AD},
+  keywords     = {patristic},
+}
+
+@book{sulpicius:chronica,
+  author       = {Sulpicius Severus},
+  title        = {Chronica},
+  origlanguage = {latin},
+  note         = {Written c.~403 AD},
+  keywords     = {patristic},
+}
+
+@book{victorinus:apocalypse,
+  author       = {Victorinus of Pettau},
+  title        = {Commentary on the Apocalypse},
+  origlanguage = {latin},
+  note         = {Written c.~late third century AD},
+  keywords     = {patristic},
+}
+
+@book{cyprian:lapsed,
+  author       = {Cyprian of Carthage},
+  title        = {De Lapsis},
+  origlanguage = {latin},
+  note         = {Written c.~251 AD},
+  keywords     = {patristic},
+}
+
+% --- Additional modern scholarship ---
+
+@book{hillar:logos,
+  author    = {Hillar, Marian},
+  title     = {From Logos to Trinity},
+  subtitle  = {The Evolution of Religious Beliefs from Pythagoras to Tertullian},
+  publisher = {Cambridge University Press},
+  location  = {Cambridge},
+  year      = {2012},
+  keywords  = {modern},
+}
+
+@book{attridge:essays,
+  author    = {Attridge, Harold W.},
+  title     = {Essays on John and Hebrews},
+  publisher = {Mohr Siebeck},
+  location  = {T\"ubingen},
+  year      = {2010},
+  keywords  = {modern},
+}
+
+@article{nongbri:p52,
+  author    = {Nongbri, Brent},
+  title     = {The Use and Abuse of P52: Papyrological Pitfalls in the Dating of the Fourth Gospel},
+  journal   = {Harvard Theological Review},
+  volume    = {98},
+  number    = {1},
+  year      = {2005},
+  pages     = {23--48},
   keywords  = {modern},
 }


### PR DESCRIPTION
## Summary
- Add 14 new bibliography entries: Quintilian, Herodotus, Xenophon (Cyropaedia), Philo (Legum Allegoriarum, Quis Heres), Lactantius (2 works), Sulpicius Severus, Victorinus, Cyprian, Hillar, Attridge, Nongbri
- Convert ~60 inline citations across chapters 2-6 to formal `\cite[passage]{key}` commands
- Covers ancient historians (Josephus, Tacitus, Seneca, Cicero, Plutarch, Herodotus), Philo (6 works), patristic authors (Irenaeus, Tertullian, Origen, Eusebius, Augustine, Clement, Victorinus), and modern scholars (Dodd, Borgen, Boyarin, Runia, Hillar, Attridge, Nongbri, Schrader Polczer)
- Total: 79 `\cite` commands across all 6 chapters

## What stays inline
- Bible verses, papyrus numbers, inscription corpora (per CLAUDE.md)
- Egyptian/Buddhist/Zoroastrian sacred corpora (analogous to Bible)

## Test plan
- [x] XeLaTeX build succeeds (258 pages, no errors)
- [ ] CI PDF build passes (LuaLaTeX)
- [ ] Bibliography renders all new entries correctly
- [ ] No undefined citation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)