### PR TITLE
feat: wrong_chapter redistribution pipeline

### DIFF
--- a/scripts/build_coverage.py
+++ b/scripts/build_coverage.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+build_coverage.py — DD-0002 Step 1 batch preparation and verdict management.
+
+Manages the full-scale coverage evaluation pipeline:
+1. Parses all Alexandria extraction findings
+2. Groups findings by chapter
+3. Excludes already-evaluated findings
+4. Generates evaluation batches for agent processing
+5. Merges agent verdicts into per-chapter verdict files
+
+Usage:
+    python scripts/build_coverage.py --status               # Pipeline status
+    python scripts/build_coverage.py --batches               # Generate all batches
+    python scripts/build_coverage.py --batches --chapter 3    # Ch3 batches only
+    python scripts/build_coverage.py --merge FILE --chapter 3 # Merge verdicts
+    python scripts/build_coverage.py --normalize              # Normalize formats
+    python scripts/build_coverage.py --redistribute           # Redistribute wrong_chapter (round 1)
+    python scripts/build_coverage.py --redistribute --round 2 # Round 2+ redistribution
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SOURCES_DIR = PROJECT_ROOT / "sources"
+YOUTUBE_DIR = SOURCES_DIR / "youtube"
+COVERAGE_DIR = SOURCES_DIR / "coverage"
+
+BATCH_SIZE = 15  # findings per evaluation batch
+
+# Import the existing extraction parser
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from review_extractions import parse_all_extractions
+
+
+def load_inventory(chapter: int) -> list:
+    """Load the coverage inventory for a chapter."""
+    path = COVERAGE_DIR / f"ch{chapter}_inventory.json"
+    if not path.exists():
+        return []
+    return json.loads(path.read_text())
+
+
+def load_verdicts(chapter: int) -> dict:
+    """Load existing verdicts for a chapter. Returns {finding_id: verdict_dict}."""
+    path = COVERAGE_DIR / f"ch{chapter}_validation_verdicts.json"
+    if not path.exists():
+        return {}
+
+    data = json.loads(path.read_text())
+
+    # Normalize: dict format (ch3) → standard lookup
+    if isinstance(data, dict):
+        result = {}
+        for fid, v in data.items():
+            verdict = v.get("verdict") or v.get("step1_verdict", "")
+            result[fid] = {
+                "finding_id": fid,
+                "verdict": verdict,
+                "justification": v.get("justification", ""),
+            }
+        return result
+
+    # Array format (all other chapters)
+    result = {}
+    for entry in data:
+        fid = entry.get("finding_id", "")
+        if fid:
+            result[fid] = entry
+    return result
+
+
+def save_verdicts(chapter: int, verdicts: dict):
+    """Save verdicts in standardized array format."""
+    path = COVERAGE_DIR / f"ch{chapter}_validation_verdicts.json"
+    # Convert to sorted array
+    arr = sorted(verdicts.values(), key=lambda x: x.get("finding_id", ""))
+    path.write_text(json.dumps(arr, indent=2, ensure_ascii=False))
+
+
+def get_all_findings_by_chapter() -> dict:
+    """Parse all extractions and group by primary chapter."""
+    findings = parse_all_extractions()
+    by_chapter = defaultdict(list)
+    for f in findings:
+        for ch in f.chapter_nums:
+            by_chapter[ch].append(f)
+    return by_chapter
+
+
+def cmd_status(args):
+    """Show pipeline status."""
+    by_chapter = get_all_findings_by_chapter()
+
+    print("DD-0002 Step 1 Pipeline Status")
+    print("=" * 65)
+    print(f"{'Ch':<4} {'Total':<8} {'Evaluated':<10} {'Remaining':<10} {'Inventory':<10}")
+    print("-" * 65)
+
+    total_all = 0
+    eval_all = 0
+
+    for ch in sorted(by_chapter.keys()):
+        if ch == 0:
+            continue  # skip preface
+        total = len(by_chapter[ch])
+        verdicts = load_verdicts(ch)
+        evaluated = len(verdicts)
+        inventory = load_inventory(ch)
+        inv_count = len(inventory)
+        remaining = total - evaluated
+
+        total_all += total
+        eval_all += evaluated
+
+        print(f"Ch{ch:<3} {total:<8} {evaluated:<10} {remaining:<10} {inv_count:<10}")
+
+    print("-" * 65)
+    print(f"{'All':<4} {total_all:<8} {eval_all:<10} {total_all - eval_all:<10}")
+
+    # Show verdict distribution for evaluated findings
+    print("\nVerdict Distribution (evaluated findings):")
+    all_verdicts = Counter()
+    for ch in sorted(by_chapter.keys()):
+        if ch == 0:
+            continue
+        verdicts = load_verdicts(ch)
+        for v in verdicts.values():
+            verdict = v.get("verdict", "unknown")
+            all_verdicts[verdict] += 1
+
+    for verdict, count in all_verdicts.most_common():
+        pct = count / eval_all * 100 if eval_all > 0 else 0
+        print(f"  {verdict:<16} {count:>4} ({pct:.1f}%)")
+
+
+def cmd_batches(args):
+    """Generate evaluation batches."""
+    by_chapter = get_all_findings_by_chapter()
+    chapters = [args.chapter] if args.chapter else sorted(ch for ch in by_chapter if ch > 0)
+
+    COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
+    batches_dir = COVERAGE_DIR / "batches"
+    batches_dir.mkdir(parents=True, exist_ok=True)
+
+    total_batches = 0
+
+    for ch in chapters:
+        findings = by_chapter.get(ch, [])
+        if not findings:
+            print(f"Ch{ch}: No findings")
+            continue
+
+        # Load existing verdicts to exclude
+        existing = load_verdicts(ch)
+        unevaluated = [f for f in findings if f.finding_id not in existing]
+
+        if not unevaluated:
+            print(f"Ch{ch}: All {len(findings)} findings already evaluated")
+            continue
+
+        # Load inventory
+        inventory = load_inventory(ch)
+        if not inventory:
+            print(f"Ch{ch}: WARNING — no inventory found, skipping")
+            continue
+
+        # Generate batches
+        ch_batches = []
+        for i in range(0, len(unevaluated), BATCH_SIZE):
+            batch_findings = unevaluated[i:i + BATCH_SIZE]
+            batch = {
+                "chapter": ch,
+                "batch_index": len(ch_batches),
+                "total_batches_for_chapter": -1,  # filled below
+                "findings": [
+                    {
+                        "finding_id": f.finding_id,
+                        "channel": f.channel,
+                        "video_title": f.video_title,
+                        "status": f.status,
+                        "description": f.description,
+                        "quote": f.quote,
+                    }
+                    for f in batch_findings
+                ],
+            }
+            ch_batches.append(batch)
+
+        # Fill total count
+        for b in ch_batches:
+            b["total_batches_for_chapter"] = len(ch_batches)
+
+        # Write batch files
+        for b in ch_batches:
+            batch_path = batches_dir / f"ch{ch}_batch_{b['batch_index']:03d}.json"
+            batch_path.write_text(json.dumps(b, indent=2, ensure_ascii=False))
+
+        total_batches += len(ch_batches)
+        print(f"Ch{ch}: {len(unevaluated)} unevaluated findings → {len(ch_batches)} batches")
+
+    print(f"\nTotal: {total_batches} batches written to {batches_dir}/")
+
+
+def cmd_merge(args):
+    """Merge agent verdict results into chapter verdict files."""
+    if not args.chapter:
+        print("ERROR: --chapter required with --merge", file=sys.stderr)
+        return 1
+
+    merge_path = Path(args.merge)
+    if not merge_path.exists():
+        print(f"ERROR: {merge_path} not found", file=sys.stderr)
+        return 1
+
+    new_data = json.loads(merge_path.read_text())
+
+    # Support both array and dict formats from agents
+    new_verdicts = {}
+    if isinstance(new_data, list):
+        for entry in new_data:
+            fid = entry.get("finding_id", "")
+            if fid:
+                new_verdicts[fid] = entry
+    elif isinstance(new_data, dict):
+        for fid, v in new_data.items():
+            new_verdicts[fid] = {"finding_id": fid, **v}
+
+    existing = load_verdicts(args.chapter)
+    added = 0
+    updated = 0
+    for fid, verdict in new_verdicts.items():
+        if fid in existing:
+            updated += 1
+        else:
+            added += 1
+        existing[fid] = verdict
+
+    save_verdicts(args.chapter, existing)
+    print(f"Ch{args.chapter}: merged {added} new + {updated} updated → {len(existing)} total")
+
+
+def cmd_normalize(args):
+    """Normalize all verdict files to array format."""
+    for ch in range(1, 7):
+        verdicts = load_verdicts(ch)
+        if not verdicts:
+            continue
+        save_verdicts(ch, verdicts)
+        print(f"Ch{ch}: normalized {len(verdicts)} verdicts to array format")
+
+
+MAX_REDISTRIB_ROUNDS = 3
+
+
+def parse_target_chapter(entry: dict, source_ch: int) -> int | None:
+    """Extract target chapter from a wrong_chapter verdict.
+
+    Handles three formats:
+    1. explicit suggested_chapter field (int like 4, or string like "ch5")
+    2. regex "Chapter N" in justification text
+    3. regex "Chapter N" in rationale text
+    Returns target chapter int, or None if unparseable.
+    """
+    # Method 1: explicit suggested_chapter field
+    sc = entry.get("suggested_chapter")
+    if sc is not None:
+        if isinstance(sc, int):
+            if 1 <= sc <= 6 and sc != source_ch:
+                return sc
+        elif isinstance(sc, str):
+            # Handle "ch5", "Ch3", "chapter 4", or bare "5"
+            m = re.search(r"(\d)", sc)
+            if m:
+                ch = int(m.group(1))
+                if 1 <= ch <= 6 and ch != source_ch:
+                    return ch
+
+    # Method 2/3: regex from justification or rationale
+    text = entry.get("justification", "") or entry.get("rationale", "")
+    if not text:
+        return None
+
+    matches = re.findall(r"[Cc]hapter\s*(\d)", text)
+    targets = [int(m) for m in matches if int(m) != source_ch and 1 <= int(m) <= 6]
+    if targets:
+        return targets[0]
+
+    # Also try "Ch3" / "ch5" patterns (common in verdict text)
+    matches = re.findall(r"[Cc]h\s*(\d)", text)
+    targets = [int(m) for m in matches if int(m) != source_ch and 1 <= int(m) <= 6]
+    if targets:
+        return targets[0]
+
+    return None
+
+
+def load_verdict_files(chapter: int, round_num: int) -> list[dict]:
+    """Load verdict entries from appropriate files for a given round.
+
+    Round 1: scans ch{N}_verdicts_opus_*.json (main evaluation)
+    Round 2+: scans ch{N}_verdicts_opus_redistrib_r{round-1}.json only
+    """
+    entries = []
+
+    if round_num == 1:
+        # Main evaluation: all opus verdict files (excluding redistrib files)
+        pattern = f"ch{chapter}_verdicts_opus_*.json"
+        for path in sorted(COVERAGE_DIR.glob(pattern)):
+            if "redistrib" in path.name:
+                continue
+            data = json.loads(path.read_text())
+            if isinstance(data, list):
+                entries.extend(data)
+            elif isinstance(data, dict):
+                for fid, v in data.items():
+                    entries.append({"finding_id": fid, **v})
+
+        # Also check consolidated validation_verdicts
+        val_path = COVERAGE_DIR / f"ch{chapter}_validation_verdicts.json"
+        if val_path.exists():
+            data = json.loads(val_path.read_text())
+            seen = {e.get("finding_id") for e in entries}
+            if isinstance(data, list):
+                for e in data:
+                    if e.get("finding_id") not in seen:
+                        entries.append(e)
+            elif isinstance(data, dict):
+                for fid, v in data.items():
+                    if fid not in seen:
+                        entries.append({"finding_id": fid, **v})
+    else:
+        # Round 2+: only previous round's redistribution verdicts
+        prev = round_num - 1
+        pattern = f"ch{chapter}_verdicts_opus_redistrib_r{prev}.json"
+        path = COVERAGE_DIR / pattern
+        if path.exists():
+            data = json.loads(path.read_text())
+            if isinstance(data, list):
+                entries.extend(data)
+            elif isinstance(data, dict):
+                for fid, v in data.items():
+                    entries.append({"finding_id": fid, **v})
+
+    return entries
+
+
+def cmd_redistribute(args):
+    """Redistribute wrong_chapter findings to correct chapters."""
+    round_num = args.round or 1
+
+    if round_num > MAX_REDISTRIB_ROUNDS:
+        print(f"ERROR: max {MAX_REDISTRIB_ROUNDS} redistribution rounds", file=sys.stderr)
+        return 1
+
+    # Build finding content lookup from parse_all_extractions()
+    all_findings = parse_all_extractions()
+    content_by_id = {}
+    for f in all_findings:
+        content_by_id[f.finding_id] = {
+            "finding_id": f.finding_id,
+            "text": f.description,
+            "quote": f.quote,
+        }
+
+    # Fallback: alexandria_reextraction.json
+    reextract_path = COVERAGE_DIR / "alexandria_reextraction.json"
+    if reextract_path.exists():
+        reextract = json.loads(reextract_path.read_text())
+        for entry in reextract:
+            fid = entry.get("finding_id", "")
+            if fid and fid not in content_by_id:
+                content_by_id[fid] = {
+                    "finding_id": fid,
+                    "text": entry.get("text", ""),
+                    "quote": entry.get("quote", ""),
+                }
+
+    # Load previous-round redistribution history for ping-pong detection
+    prev_redistributed = set()
+    if round_num >= 2:
+        for prev_round in range(1, round_num):
+            for ch in range(1, 7):
+                path = COVERAGE_DIR / f"ch{ch}_findings_redistrib_r{prev_round}.json"
+                if path.exists():
+                    data = json.loads(path.read_text())
+                    for entry in data:
+                        prev_redistributed.add(entry.get("finding_id", ""))
+
+    # Collect wrong_chapter verdicts from all chapters
+    # Key: target_chapter -> list of {finding_id, text, quote, source_ch}
+    by_target = defaultdict(list)
+    unparseable = []
+    ping_pong = []
+    total_wrong = 0
+
+    for source_ch in range(1, 7):
+        entries = load_verdict_files(source_ch, round_num)
+        for entry in entries:
+            if entry.get("verdict") != "wrong_chapter":
+                continue
+
+            total_wrong += 1
+            fid = entry.get("finding_id", "")
+
+            target = parse_target_chapter(entry, source_ch)
+            if target is None:
+                unparseable.append((fid, source_ch, entry))
+                continue
+
+            # Ping-pong detection: finding redistributed in a previous round
+            if fid in prev_redistributed:
+                ping_pong.append((fid, source_ch, target))
+                continue
+
+            # Look up content
+            content = content_by_id.get(fid)
+            if content is None:
+                print(f"  WARNING: no content for {fid} (source ch{source_ch})")
+                continue
+
+            # Safety: target must differ from source
+            if target == source_ch:
+                continue
+
+            by_target[target].append({
+                "finding_id": fid,
+                "text": content["text"],
+                "quote": content["quote"],
+                "source_chapter": source_ch,
+            })
+
+    # Print summary
+    print(f"Redistribution Round {round_num}")
+    print("=" * 55)
+    print(f"Total wrong_chapter verdicts: {total_wrong}")
+
+    if not by_target:
+        print("\nNo findings to redistribute. Converged.")
+        if unparseable:
+            print(f"\n{len(unparseable)} unparseable (no target chapter detected):")
+            for fid, sch, _ in unparseable:
+                print(f"  {fid} (from ch{sch})")
+        if ping_pong:
+            print(f"\n{len(ping_pong)} ping-pong (flagged for manual review):")
+            for fid, sch, tgt in ping_pong:
+                print(f"  {fid}: ch{sch} → ch{tgt}")
+        return 0
+
+    print(f"\nRedistribution:")
+    total_redistributed = 0
+    for target_ch in sorted(by_target.keys()):
+        findings = by_target[target_ch]
+        sources = Counter(f["source_chapter"] for f in findings)
+        source_str = ", ".join(f"ch{s}:{c}" for s, c in sorted(sources.items()))
+        print(f"  → Ch{target_ch}: {len(findings)} findings (from {source_str})")
+        total_redistributed += len(findings)
+
+    # Write batch files
+    COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
+    files_written = []
+
+    for target_ch in sorted(by_target.keys()):
+        findings = by_target[target_ch]
+        out_path = COVERAGE_DIR / f"ch{target_ch}_findings_redistrib_r{round_num}.json"
+        out_data = [
+            {
+                "finding_id": f["finding_id"],
+                "text": f["text"],
+                "quote": f["quote"],
+                "source_chapter": f["source_chapter"],
+            }
+            for f in findings
+        ]
+        out_path.write_text(json.dumps(out_data, indent=2, ensure_ascii=False))
+        files_written.append(out_path.name)
+
+    print(f"\n{total_redistributed} findings → {len(files_written)} batch files:")
+    for name in files_written:
+        print(f"  {COVERAGE_DIR / name}")
+
+    if unparseable:
+        print(f"\n{len(unparseable)} unparseable (no target chapter detected):")
+        for fid, sch, _ in unparseable:
+            print(f"  {fid} (from ch{sch})")
+
+    if ping_pong:
+        print(f"\n{len(ping_pong)} ping-pong (flagged for manual review):")
+        for fid, sch, tgt in ping_pong:
+            print(f"  {fid}: ch{sch} → ch{tgt}")
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="DD-0002 Step 1 coverage pipeline management"
+    )
+    parser.add_argument("--status", action="store_true", help="Show pipeline status")
+    parser.add_argument("--batches", action="store_true", help="Generate eval batches")
+    parser.add_argument("--merge", type=str, help="Merge verdict results from file")
+    parser.add_argument("--normalize", action="store_true", help="Normalize formats")
+    parser.add_argument("--redistribute", action="store_true",
+                        help="Redistribute wrong_chapter findings")
+    parser.add_argument("--round", type=int, default=1,
+                        help="Redistribution round number (default: 1)")
+    parser.add_argument("--chapter", type=int, help="Limit to specific chapter")
+    args = parser.parse_args()
+
+    if args.status:
+        return cmd_status(args)
+    elif args.batches:
+        return cmd_batches(args)
+    elif args.merge:
+        return cmd_merge(args)
+    elif args.normalize:
+        return cmd_normalize(args)
+    elif args.redistribute:
+        return cmd_redistribute(args)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/sources/coverage/ch1_findings_redistrib_r1.json
+++ b/sources/coverage/ch1_findings_redistrib_r1.json
@@ -1,0 +1,20 @@
+[
+  {
+    "finding_id": "fTjva6UwLE4_6",
+    "text": "Early Christian polemics echo Greco-Egyptian descent-to-Hades narratives (Orpheus myth), but with Christian \"one-upmanship\": while Orpheus fails to retrieve his wife from Hades, Jesus succeeds in rescuing righteous souls imprisoned for millennia, demonstrating superior divine power and authority.",
+    "quote": "you've got to be thinking to yourself where orpheus failed it's it's not in his power to take his wife back...well that's not what happens for for jesus jesus takes up everybody who's righteous since adam and eve...christianity is a whole lot better",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "65Ii0MVe7hA_0",
+    "text": "Dennis MacDonald's analysis of Homeric mimesis in the Gospel of Mark supports the book's Greco-Christian framework thesis. The parallel between Homer's account of Hermes conducting Priam past sleeping guards and open doors (Iliad 24) and Mark's resurrection narrative (guards struck senseless, tomb opened) demonstrates how Gospel authors used Greek literary structures to convey theological concepts about divine power and authority.",
+    "quote": "in the gospel of mark is an unusual narrative about guards at the tomb then falls are stricken like dead men when jesus comes out of the tomb that is the tomb is open the guards are put to sleep and the words for guards and for the door are exactly the same as you have in homework",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "qaGz4eDqIUA_0",
+    "text": "Egyptian theology of divine kingship—understanding a king as simultaneously human and divine—provides institutional-theological precedent for \"Son of God\" as political designation rather than metaphysical claim.",
+    "quote": "Egyptians grappled with this arguably more than anybody else because the king is human and here on Earth and yet is meant to be The Offspring of divinity right so how do you have human being on Earth who is divine who will still die... Jesus is a part of that discussion he is part Divine he is part human he is Mortal he can be killed he can be reborn",
+    "source_chapter": 6
+  }
+]

--- a/sources/coverage/ch2_findings_redistrib_r1.json
+++ b/sources/coverage/ch2_findings_redistrib_r1.json
@@ -1,0 +1,164 @@
+[
+  {
+    "finding_id": "3rH8HdbQEjs_0",
+    "text": "Tobolovsky identifies Greek genealogical models (panhellenism, which created unified Greek identity through descent from Helen) as directly influencing the Jewish construction of \"pan-israelitism\" through the 12-tribe genealogy. This demonstrates that Greek institutional frameworks were embedded in fundamental Jewish thought about political identity and community organization.",
+    "quote": "we have them mainly in ancient greece... we can see this genealogy being used to expand and include groups that it didn't originally include to create panhellenism and i think it's reasonable to say that... something like that happened in israel as well where the genealogy was expanded to combine judah and israel in the same way and create what might call it pan israelitism and i do think that that would point to a kind of hellenistic influence",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "dc6mYzh9MWg_0",
+    "text": "The speaker argues that Jesus should be understood as deeply engaged with Greek philosophy, specifically as \"an excellent stoic,\" rather than through a purely Jewish framework. This directly supports the book's core argument for a Greco-Christian interpretive lens over the dominant Judeo-Christian scholarly approach.",
+    "quote": "he knows Jewish scripture he's a Judean you know he's Jewish but he also knows the Greek philosophy apparently really really well because he's an excellent stoic as it turns out",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "LSpAmwwlSaI_0",
+    "text": "The speaker hypothesizes that Paul's churches in Asia Minor consisted of pre-existing communities of \"God-fearers\" already worshipping the Most High God under Hellenistic frameworks—providing evidence that Paul's institutional context involved Greek religious communities rather than Jewish ones.",
+    "quote": "My own personal hypothesis is that the churches of Asia that Paul is writing to were already worshippers of God most high, who were already free from the laws of the Jews, but were still what scholars call God-fearers.",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "meHCQWihjCw_0",
+    "text": "Magness describes how Herod expressed his political power and claims to messianic legitimacy through monumental religious architecture and symbolic tomb placement. This exemplifies how messianic and royal claims were inextricably bound with political institutions and theological expression in the Hellenistic context of first-century Judea, supporting the book's argument that kingship claims were expressed through institutional means.",
+    "quote": "Herod claimed to have fulfilled the expectations associated with a Davidic Messiah... we see this represented also, for example, in his rebuilding of the second temple in Jerusalem on a massive scale... the recently discovered tomb of Herod... located at a mountain called Herodium overlooking Bethlehem",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "KGMXVRjfPW8_1",
+    "text": "Adler's discussion of Herod maintaining Jewish ritual immersion pools directly adjacent to the Temple of Augustus demonstrates the dual Greco-Roman/Jewish institutional framework operating simultaneously in the first century, supporting the book's thesis that both systems coexisted within the same political and cultural space.",
+    "quote": "we find these Jewish ritual baths not only do we find them everywhere where we have Jews but we even find them adjacent to a pagan Temple to my mind there's there's this is really an indication of how widespread uh Torah observance was at this time... despite the fact that he's building this the the this Pagan Temple he still has his his Jewish ritual best that he's building uh directly adjacent to the to the temple",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "KjBx7KgsJxg_2",
+    "text": "The documentary provides detailed analysis of how the Exodus narrative incorporated Platonic philosophical concepts and Greek political institutional models, showing that the theological and political frameworks were Hellenistically constructed rather than purely Jewish.",
+    "quote": "Philip vajin bom points out how similar the Bible stories are to what Plato wrote for starters both talk about a big flood that changed the world and was followed by a time when Patriarchs ruled... both stress having a central religious power... they divide the ideal State into 12 Parts each given to a different tribe or group",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "LrxET9ss0Cg_1",
+    "text": "Neil cites Plutarch's account of Harpocrates (Horus child) being born on the winter solstice to Isis, providing comparative evidence from Greco-Roman mythology for understanding nativity narratives within a religious-cultural context beyond Jewish apocalyptic tradition.",
+    "quote": "Plutarch writes Harpocrates Horus child is born on the winter solstice to Isis 160 years before Soul Invictus",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "z9gvRY3yQL4_3",
+    "text": "Mason explicitly states that monogamy as a standard became established \"under Greek and Roman influence\" rather than from Judean tradition, showing how Greco-Roman institutional norms shaped evolving practices in this period.",
+    "quote": "it looks like under Roman influence um Jews living under Roman influence or Greco Roman influence um evolved into this idea of one one husband one wife",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "DEEHRO8DFBY_1",
+    "text": "Tabor describes Jesus's succession by his brother James as a dynastic \"caliphate\" — a formal political succession pattern. This supports the book's argument that Jesus's movement operated as a political institution with inherited authority and dynastic continuity, not merely as a spiritual community.",
+    "quote": "when jesus dies he's succeeded by his brother james who's of the same bloodline so it's what we call a caliphate",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "Z9vKV3v_IU0_3",
+    "text": "Tabor frames James's succession to Jesus as leader of the movement in dynastic terms, supporting the book's political-institutional interpretation of the Kingdom.",
+    "quote": "when Jesus dies, James, the brother of Jesus, takes over leadership of the movement... Jesus is considered, I think, senior as the elder and also the Messiah by his followers. But the movement continues.",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "rXUmjzDH8lw_3",
+    "text": "The Temple Mount itself was Herod's statement of power in Greco-Roman style: \"the largest temple and compound in all of the ancient world nothing in Rome Rivals this.\" Though respecting Jewish law internally, the Temple's overall design and decoration followed Greco-Roman architectural conventions.",
+    "quote": "when you talk about Jewish art and architecture I'm thinking herod's palace here the different homes the temple it's Jewish but it's probably in the style of Greco-Roman art and architecture",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "6bqScTN2wRs_4",
+    "text": "Lawson presents Talpiyot Tomb ossuary evidence showing Mary Magdalene (Mariamne) was Jesus's wife, with inscriptions indicating her role as teacher (rabbi): \"one of the ossuaries was has the name miriam knee...many legends and traditions say that Jesus was married and many people specify that he married Mary of Magdala or Mary Magdalene.\"",
+    "quote": "one of the ossuaries has the name miriam knee...many legends and traditions say that Jesus was married and many people specify that he married Mary of Magdala",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "Jor0oevcEK8_5",
+    "text": "The Migdal stone—a temple artifact likely associated with Jesus's era—contains an encoded model of the astrological universe with precise planetary positions from April 17, 6 BCE, demonstrating that Greek astronomical knowledge was embedded in Jewish cultic practice.",
+    "quote": "the migdal stone models a universe that represents exactly the same planetary positions and sky that happened on April 17th 6 BCE...the menorah literally represents all the Heavenly lights occupying only the constellations Taurus Aries and Pisces",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "PmE7ZMpWjRw_1",
+    "text": "The speaker emphasizes that the entire Mediterranean became a unified Hellenized culture during the Hellenistic period, directly supporting the book's argument that early Christian institutions spread through Hellenistic cities and reflected Greek political frameworks.",
+    "quote": "I like people to become aware of the degree to which the Mediterranean had become one Hellenized culture we call it the Hellenistic period Hellenistic means these are the people who have learned Greek but it wasn't their native tongue",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "TOtKGiV7RYI_0",
+    "text": "Gmirkin describes how Jewish governance in the 270s BC directly imitated Platonic institutional structures. He notes that Plato's Laws prescribe a \"nocturnal council\" composed of \"leading experts in theology and philosophy and ethics and government of the educated elites including the the current and all past high priests,\" and identifies this as the explicit model for new Jewish governance structures—a theocratic political assembly structured on Greek philosophical principles.",
+    "quote": "in plato's laws uh his senate or ruling council was called the the nocturnal council...it was composed of leading experts in theology and philosophy and ethics and government of the educated elites including the the current and all past high priests...the new form of jewish government in the two in the 270s bc who was led by a high priest you know that's directly an imitation of plato's laws",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "s1P6w4hbNt8_0",
+    "text": "Multiple speakers discuss Gmirkin's demonstration that Greek law codes (Athenian, Roman, and Platonic) show extensive overlap with Hebrew biblical law codes, establishing that Hellenistic institutional and legal frameworks significantly influenced biblical redaction. This supports the book's argument that Greek political and institutional categories would provide natural templates for understanding early Christian institutional structures like the ekklesia.",
+    "quote": "There's like an 85% overlap between the Old Testament mundane law codes and not just mundane law codes, sacred law, and what we find in Athenian, Plato, and Roman laws.",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "5cqruE4LYyY_4",
+    "text": "The podcast extensively describes the Seleucid creation of Greek political and administrative institutions (gymnasiums, theaters, magistracies, divided city quarters) throughout the Near East, providing the institutional framework and precedent for Paul's later establishment of assemblies in Hellenistic cities.",
+    "quote": "antioch itself was divided into quarters some explicitly settled by macedonians while the others were likely inhabited by other greek communities or indigenous peoples...this doesn't appear to be a policy of ghettoization and segregation on the part of the seleucid government",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "aoRA4W-9QBI_1",
+    "text": "Greco-Bactrian administrative organization demonstrates the hierarchical Hellenistic institutional model with Greek language and elite authority at the apex, local populations in subordinated administrative roles—a structure that contextualizes the book's argument about ekklesia as Greek political assembly adapted in early Christian contexts.",
+    "quote": "greek remained the dominant language of the administrative class...it is likely that like with egypt officials drawn from the local bactrian communities would continue to be employed in the government though perhaps in the lower levels while the greeks continue to form the upper stratum of the elite",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "KGMXVRjfPW8_3",
+    "text": "Adler notes that Jewish institutions like the Seder adopted the structure of the Greek Symposium and that synagogues were modeled on Hellenistic gymnasia, demonstrating institutional Greco-Roman influence on Jewish religious practice, which the book frames as foundational to understanding Greco-Christian institutional development.",
+    "quote": "the Seder was a symposium it was based on the Greek Symposium... the synagogue as the ultimate uh educational Institution for Jews... where does that come from right that's born out of a vacuum that came out you know that was born out of the larger Hellenistic uh Roman world",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "5b9KDuPZiP0_3",
+    "text": "Tabor maps Jesus's ministry across the ten Hellenistic cities of the Decapolis (Damascus, Philadelphia/Amman, Gadara, Pella, and others), demonstrating Jesus drawing large crowds from a distributed network of Greek city-states. This supports the argument about ekklesia as a Greek political assembly geographically organized through Hellenistic cities.",
+    "quote": "These 10 cities...after the Roman conquest of 63 they're very Roman or helenistic...all the way down from the 4th to the 2 Century so by the time of the first century uh they are just booming centers of Greek culture...he's going all the way up here and around all the cities of the decapolis so he has concentrated work in this area and he's drawing crowds from down south",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "5b9KDuPZiP0_4",
+    "text": "Tabor documents the Roman administrative infrastructure (roads, city governance structures, Roman military presence) that organized Jesus's ministry region, supporting the context for understanding early community organization within Roman colonial administration.",
+    "quote": "Here's a network of the roads...all these roads so we read about how Jesus goes from the cities of tyrant sidon he comes down to the G and then he goes across the Jordan you see the route he would have taken and up and down these various roads to hit all of the major cities",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "9my0DBEb4q0_2",
+    "text": "Tabor documents the Roman administrative infrastructure embedded in Jesus's Capernaum headquarters—specifically identifying \"a Roman Centurion station at Capernaum\" and Matthew as tax collector at the \"toll station for travelers.\" This provides concrete evidence addressing the Chapter 5 thin area of \"specific institutional parallels, Roman colonial administration details.\"",
+    "quote": "there's a Roman Centurion station at Capernaum keep that in mind because we're going to talk about the Strategic importance of this place...he knows a Roman Centurion and he knows somebody officially in the government of the time",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "CDv-GWPp_Zs_3",
+    "text": "The inclusion of Magi (non-Jewish magicians from Parthia) in Matthew's account reflects a broader Hellenistic metaphysical worldview beyond strictly Jewish frameworks, incorporating Persian and Levantine religious traditions alongside Jewish ones.",
+    "quote": "the Magi were from Parthia the East they were the you know magic magicians so to speak they were not under the same sort of you know staunch Jewish you know Paradigm and so you could see in Matthew a broader kind of metaphysical world that is more encompassing of the Levant generally and not just Judaism",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "CDv-GWPp_Zs_4",
+    "text": "Proskinesis (bowing/veneration) is identified as a cardinal importance in Alexander's imperial ideology and appears in Matthew's account of the Magi bending the knee to Jesus, establishing a direct parallel in Hellenistic royal protocol.",
+    "quote": "if you're going to rule in the Persian East you need proskinesis you need people bowing to you as a Divine figure... when they come and bring their gifts and all that to meet with them they've also they also do proskinesis",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "z9gvRY3yQL4_2",
+    "text": "Mason describes Caesarea as a model Greco-Roman institutional city with \"a Temple to Augustus and Rome right at right in the center of the harbor...the place is filled with entertainment facilities...big uh theater Amphitheater,\" establishing the Greco-Roman political-religious context in which early Christian communities developed.",
+    "quote": "cesaria...is a GRE Roman city and that's clear because there's a Temple to Augustus and Rome right at right in the center of the harbor...the place is filled with entertainment facilities",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "QX6VwZHbgvs_4",
+    "text": "Tabor shows that Origen and Epiphanius responded to the Pantera charge not by dismissing it as pagan slander, but by accepting \"Pantera\" as a legitimate Jewish family name (Jesus's grandfather, Joseph's father). This demonstrates early Church Fathers' institutional sophistication in defending Christian claims while preserving genealogical plausibility within Jewish-Hellenistic naming conventions.",
+    "quote": "what do they say yeah it's true there is a guy named Panthers in the family can you believe that they say that he was Joseph's father Jesus legal Father Joseph his father was named Pantera... they're accepting it their strategies to accept it",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "QX6VwZHbgvs_0",
+    "text": "Tabor provides specific Hellenistic parallels for the Virgin birth narrative, citing divine paternity of extraordinary figures in Greek and Roman sources (Heracles, Romulus) as a comparative framework for understanding how the Gospel birth narratives developed. This supports the book's emphasis on Hellenistic institutional context.",
+    "quote": "in all sorts of Hellenistic texts Greco-Roman text... the Divine man the idea of a human who is so extraordinary he must have a God for a father is very common in Greek and Roman literature",
+    "source_chapter": 6
+  }
+]

--- a/sources/coverage/ch3_findings_redistrib_r1.json
+++ b/sources/coverage/ch3_findings_redistrib_r1.json
@@ -1,0 +1,308 @@
+[
+  {
+    "finding_id": "w7KScjwdwoQ_1",
+    "text": "The scholar critiques the conventional scholarly view that Jesus's power to forgive sins proves he is God, calling it a \"postbiblical rationalization of the Trinity that entirely ignores Greco Roman period Jewish ideas about the communicability of God's power and authority.\"",
+    "quote": "the notion that the power to forgive sins is God's alone and if someone can forgive sins that means they are God is a postbiblical rationalization of the Trinity that entirely ignores Greco Roman period Jewish ideas about the communicability of God's power and authority",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "dO0AC1QyLVE_4",
+    "text": "Philo's Platonic framework is explicitly described as transforming Judaism into \"Platonized Judaism,\" with Philo's theology including a logos and three-part divinity structure, suggesting Christianity's intellectual framework was fundamentally shaped by Middle Platonism rather than Jewish apocalyptic categories.",
+    "quote": "philo has an idea of god being of nature of three philo has the idea of a logos inheriting the kingdom of heaven from the father who's the father of intellect... christianity is like sort of like a judaized version or no a platinized version of judaism",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "l1UNoXlRrQk_0",
+    "text": "Dr. Price demonstrates that Greek philosophical frameworks (Neo-Platonism, middle Platonism, and the Logos concept from Heraclitus) were fundamental to early Christian theological development, supporting the book's core argument that Jesus and early Christianity must be understood through a Greco-Christian rather than Judeo-Christian framework.",
+    "quote": "Philo did kind of map out the essence in the direction that would ultimately end up in trinitarianism because he believed that there was the God which was sort of an abstraction and he was a middle plate inist and he liked to allegorize the Bible to make it pretty much platonic and stoic",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "jyMI1tvB5BI_0",
+    "text": "First-century Hellenistic-Jewish religious syncretism demonstrates the necessity of a Greco-Christian framework. The merger of Orphic and Judaic traditions in Alexandria by the first century shows why purely Jewish or purely Greek models are inadequate for understanding early Christianity.",
+    "quote": "by the time we get to the first century orphism and Judaism are starting to marry each other through our orphic texts that are used by the Jews and the Jews in Alexandria are even claiming Orpheus as one of their Prophets",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "kI799nkK5m0_0",
+    "text": "The Lord's Prayer was originally composed in Greek rather than Aramaic, establishing Greek linguistic primacy in foundational Christian texts and supporting the Greco-Christian framework thesis.",
+    "quote": "virtually all english translations are based directly on the greek which is near as we can tell is what it was originally written in and all aramaic versions are also translations directly from the greek",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "dO0AC1QyLVE_0",
+    "text": "Multiple speakers confirm that titles used for Jesus (\"Son of God,\" \"Savior\") were standard Hellenistic imperial titles, with one citing John Crossan noting these same titles appeared on Roman coins for emperors.",
+    "quote": "when you compare the coins that a bunch of terms used for jesus were used for emperors like son of god savior etc",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "sky6u0ntu24_0",
+    "text": "The transcript details the Theos Hypsos cult—monotheistic Greek worship of \"God Most High\" that thrived in Corinth, Athens, Macedonia, and other Hellenistic cities from the 3rd century BC onward, populated by \"god-fearers\" who later converted to Christianity. This provides documentary support for pre-Christian Greco-institutional foundations that facilitated Christian expansion.",
+    "quote": "these very hipos sterian were in close proxim it to the thriving Jewish communities living in Greece and Turkey it should also be noted that hipos is the Greek title for the god of the Old Testament...it is highly likely that these very people are among the earliest converts to Christianity",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "06uLtNZjlYg_3",
+    "text": "Litwa traces \"Son of God\" and \"Son of Man\" titles to Phoenician theological precedent (Baal mythology, Daniel 7), establishing pre-Christian Hellenistic royal and divine grammar whereby a father deity (El) generates a son deity who serves as the operative power. This supports understanding Jesus's titles within Greek-influenced dynastic theology.",
+    "quote": "in the vision in in in the book of daniel is quite late okay so that's like 160 60ish bce so this is quite late just you know uh 150 years before jesus but there you go you've got a father deity l and you've got a son deity they don't call him bald anymore but he's the son of man why is he the son of man well because god is a man",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "VfJT9fXmP9k_2",
+    "text": "The deliberate Hellenistic royal architecture of Augustus temples—elevated placement, mandatory ascent, visual hierarchy—exemplifies the \"Hellenistic royal grammar and court protocols\" through which dynastic authority was physically communicated in the empire.",
+    "quote": "a small temple in the highest place in the city a small temple in a high place with a plaza around it and you had to climb up and you had to go up steps and you're looking up all the time and if your neck is hurting you're getting the message",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "cKq5MyYp2UA_1",
+    "text": "Massimo de Santos's analysis of Herodotus and Persian diplomacy provides contextual evidence for the Hellenistic political-theological concepts relevant to Jesus's era. De Santos discusses how Near Eastern and Greek sources portray the Great King as a universal ruler exercising divine authority, with references to \"the supreme god jupiter zeus to be vice regent or agent to rule humans on the earth\"—concepts directly parallel to the royal ideology framework the book applies to Jesus and early Christianity.",
+    "quote": "quicker roman and hebraic literature frequently portrays the political role of the king emperor as the vice regent of god and or the gods",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "VAhw2cVRVsA_2",
+    "text": "Ehrman notes that in both Greco-Roman and Jewish thought, humans of exceptional status could be understood as divine—Romulus and Roman Emperors were exalted to divinity, and the Hebrew Bible itself calls the king of Israel \"Elohim\" (God). This supports understanding \"Son of God\" as operating within a political-royal framework.",
+    "quote": "sometimes there is a human being who was just so far superior to the rest of us... that they were so special that at the end of their lives the gods took them up and rewarded them by making them gods themselves... the king of Israel in the Hebrew Bible is sometimes called Elohim God",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "gZRZShUeclw_2",
+    "text": "The transcript provides evidence that Hellenistic royal grammar and court protocols (particularly coronation rituals and divine succession imagery) were actively employed in early Christian interpretation of Jesus, supporting the book's emphasis on understanding Jesus within Greek institutional contexts rather than purely Jewish apocalyptic frameworks.",
+    "quote": "this combination of sun moon and bright star also appears in this bit of archaeology...from a catacomb in rome it's...jewish because you see the right menorahs...jesus leaving the temple on yom kippur after doing sacrifices uh for sin sound familiar and also compared to the morning star",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "lpq4bdisHRU_2",
+    "text": "The speaker documents divine mediators in \"GRE Roman period Jewish literature\" who bore the divine name (Yakel, Metatron), establishing a Hellenistic Jewish precedent for the kind of divine mediation framework applied to Jesus. This supports the book's emphasis on Greco-Christian context over standard Judeo-Christian models.",
+    "quote": "we see in GRE Roman period Jewish literature Divine mediators who are authorized bearers of the Divine name or have the Divine name in them such as yakel in The Apocalypse of Abraham in much later Rabbi literature Metatron is the one who Bears the Divine name",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "1aYH2YNev3c_1",
+    "text": "Discussion of sacred king mythology from Babylon and Canaanite states, where kings could be addressed as divine and served as mediators between the divine and earthly realms, provides historical precedent for a Hellenistic divine-king Christology.",
+    "quote": "the sacred king mythology that uh was shared with babylon and the canaanite states and so on he was the vicar of the king of the gods on earth and could be addressed as god as as every king is in a couple of psalms",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "4I5IazzlLo8_3",
+    "text": "The transcript provides historical examples of Hellenistic royal adoption practices—Augustus was adopted by Julius Caesar (the first deified Roman), and Nero was adopted by Claudius and became emperor in preference to Claudius's biological son. This illustrates the Hellenistic royal grammar underlying early Christian \"Son of God\" concepts.",
+    "quote": "Gustus himself the first emperor was an adopted son of Julius Caesar who was the first Roman to be deified after Romulus so his son of God status was one of adoption as well",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "QX6VwZHbgvs_0",
+    "text": "Tabor provides specific Hellenistic parallels for the Virgin birth narrative, citing divine paternity of extraordinary figures in Greek and Roman sources (Heracles, Romulus) as a comparative framework for understanding how the Gospel birth narratives developed. This supports the book's emphasis on Hellenistic institutional context.",
+    "quote": "in all sorts of Hellenistic texts Greco-Roman text... the Divine man the idea of a human who is so extraordinary he must have a God for a father is very common in Greek and Roman literature",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "Xxt7Gu7jGk8_1",
+    "text": "Tabor provides evidence that Hellenistic cosmological ideas, including resurrection theology, penetrated Jewish communities during the Second Temple period. Second Maccabees records Jewish martyrs under Antiochus Epiphanes adopting belief in bodily resurrection and afterlife, demonstrating the Greco-Jewish context from which early Christianity emerged.",
+    "quote": "second macbes preserves the transition and explains it as a reaction to the martyrs... as they're dying... each one of them goes you will die and never come back but I will be raised though you cut off my limbs... God will give me a new body",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "mVtJHClo9xg_0",
+    "text": "Tabor documents how Greek philosophical concepts—specifically the immortal soul and body-soul dualism—were incorporated into Jewish theological vocabulary during the Hellenistic period rather than being indigenous to Hebrew thought. This demonstrates the pervasive influence of Greek culture on Jewish intellectual development in the Second Temple era and supports the book's thesis that Greco-Christian frameworks are essential to understanding early Christianity.",
+    "quote": "the idea begins to develop in the hellenistic period and the Greek period particularly maybe humans are unique maybe they possess a different kind of a soul or a different kind of a life",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "7eyz_P8LqqI_0",
+    "text": "The scholars confirm that Daniel 9:26 refers to Onias III, a High Priest assassinated in 171-172 BCE during the Seleucid period. This demonstrates the historical significance of the Hellenistic/Seleucid context to Second Temple Judaism, an area the book identifies as under-represented in current scholarship.",
+    "quote": "And this is widely agreed to be talking about 171 172 B.CE. Onas III who was a high priest who that would have been the anointed one being uh assassinated.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "7cB4iUIDqH8_0",
+    "text": "Carrier demonstrates that Paul's theological understanding of Jesus directly mirrors Philo's pre-Christian Hellenistic Jewish theology of the archangel as \"the firstborn son of god\" and logos—supporting the argument that \"Son of God\" and divine titles derive from Hellenistic frameworks, not uniquely Christian innovation.",
+    "quote": "when you look at paul and the way he's talking about jesus theologically it is definitely the same way that philo is talking about the archangel of many names...he's the image of god uh he's the paraclete the logos like all of these terms that eventually end up in christianity about jesus",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "qSgVRjZ_KbU_0",
+    "text": "Richard C. Miller argues that empty tomb narratives, eyewitness ascension accounts, and installation into divinity were standardized Greco-Roman protocols for apotheosis. The Proteus Peregrinus example—a second-century figure with Christian connections who publicly self-immolates, is reported to have ascended in a cloud/light, and is subsequently honored as deified—demonstrates this pattern in action. Miller notes: \"what's the protocol was to deify them to put them up in in lights forever... it's a protocol they know the pattern they know what they're supposed to do they're supposed to exalt them right then and there.\" This directly supports understanding resurrection as political-theological legitimacy claim within Hellenistic frameworks.",
+    "quote": "they're trying to honor him in his funeral by saying hey I saw him this is their way of trying to install him in the Hall of Fame",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "2sZnADzQ2yo_4",
+    "text": "The documentary reveals that 6th-century Syrian Christian authors (Jacob of Serugh, Romanos the Melodus) deliberately adapted Ishtar's ancient lamentations over Tamuz into narratives of the Virgin Mary mourning Jesus, explicitly bridging Mesopotamian goddess-mourning traditions with Christian Marian theology.",
+    "quote": "Syrian authors Jacob of Su and Romanos the Melodus composed eleies portraying the Virgin Mary's sorrow for her son at the crucifixion expressing her grief in intimate language that mirrors Ishtar's mourning for Tamos. In the 6th century AD, certain early Christians in the Middle East adapted aspects of Ishtar's lamentations for Tamos into their narratives of the Virgin Mary.",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "lUDHuY2PqMM_0",
+    "text": "maklelan argues that Greek philosophical frameworks introduced the concept of spirit as immaterial—a notion anachronistic to the Hebrew Bible—and that this appears specifically in New Testament authors educated in Greek philosophy, particularly John and Paul. This supports the book's thesis that understanding early Christianity requires a Greco-Christian framework.",
+    "quote": "the immateriality of spirit until you have the incorporation of Greco-Roman philosophical Frameworks in the Greco-Roman period which is why these Notions of spirit being immaterial are limited to certain authors within the New Testament who are more educated in Greek philosophical Frameworks like the authors of John like Paul",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "GSEkSCV4fm0_8",
+    "text": "Cooney cites Gospel of Thomas passage requiring women to become male for resurrection/kingdom entry, anchoring this otherwise puzzling saying in Egyptian practices of feminine-to-masculine gender transformation in funerary contexts for access to Osiris-identification and rebirth.",
+    "quote": "Gospel of Thomas which... says Simon Peter said to him let Mary leave us for women are not worthy of life Jesus said I myself shall lead her in order to make her Mel so that she too may become a Living spirit resembling you... For every woman who will make herself male will enter the Kingdom of Heaven... in Egypt if uh if a woman couldn't get pregnant it was blamed on the man... so in a way socially... it comes back on the man and so socially is not necessarily such a bad thing for the woman to have masculine rebirth imposed upon her",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "2sZnADzQ2yo_0",
+    "text": "The documentary identifies Eshmon, a Phoenician god of healing and oil, as worshiped across cities near Nazareth from the 7th century BCE to the 5th century CE. This provides evidence for Hellenistic religious context often underdeveloped in the book—demonstrating that Greco-Mediterranean dying-and-rising deity cults were geographically proximate to Jesus's ministry.",
+    "quote": "Ashman was clearly a syncric god passed down from Assyrian bell and synced with Ofius in Phoenicia and was venerated in the Levant from the 7th century B.C.E to the 5th century of the common era... He is also worshiped in all major cities that are in walking distance to Nazareth.",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "BqILLv1Dvl0_1",
+    "text": "Price confirms that early Christianity emerged within Hellenistic cosmopolitanism, with writers like Plutarch actively identifying parallel gods across cultures. This contextualizes Paul's use of Greek institutional language and demonstrates that the apostolic movement operated within an explicitly Greek intellectual and religious framework.",
+    "quote": "christianity began in uh the atmosphere of of hellenistic cosmopolitanism where like plutarch was saying that uh osiris has to be the same as john and isis it's just two different local names",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "bHkIpXlwOhU_3",
+    "text": "The Hilaria festival (March 22-27) documented with mourning, sacrifice, and resurrection celebration of Attis/Adonis on March 25, predating Christianity, provides comparative evidence that resurrection theology functioned as a Greco-Roman political-religious celebration, not a unique Christian claim.",
+    "quote": "March 24th fasting and mourning at his death March 25th the Hilaria rejoicing at the resurrection",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "4I5IazzlLo8_5",
+    "text": "The transcript argues that the Beatitude \"blessed are the peacemakers\" would be antithetical to Jewish revolutionary values but entirely consonant with Roman imperial ideology, showing how Christian virtues reflect Greco-Roman rather than Judeo-nationalist values.",
+    "quote": "Blessed are the peace Maker's house how's that for an important value in the Roman Empire these makers are the children of God very interesting yes very very very contrary to what you would think",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "e4nM4PJkGZo_6",
+    "text": "The documentary establishes that Paul's Gospel explicitly deployed deification language targeting non-Jewish Gentile audiences already familiar with demigod and emperor apotheosis narratives, making \"Son of God\" and post-death elevation comprehensible through Greek institutional precedent.",
+    "quote": "if Paul's gospel was going to work with the Gentiles he needed it to speak to them in a way that they understood this would have been in Translation Fable language",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "nTcMoGQl5Gw_2",
+    "text": "The speaker argues that Paul's gospel \"caught on so well among the Gentiles\" specifically because \"the Gentiles in that day, coming from that polytheistic background, had the model already... of a deity... in a dyad or a triad.\" This explains why the Greco-Christian framework naturally resonated with pagan audiences over Jewish theological categories.",
+    "quote": "maybe that is part of the reason why Paul's gospel caught on so well among the Gentiles and was not accepted by the Jews because the Gentiles... had the model already... of the idea that a deity could exist in a dyad or a triad, which was a trinity.",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "ucjFt4i-qC8_1",
+    "text": "Tabor describes the early church's creation of Sunday/\"Lord's day\" as a theological-institutional replacement for the Sabbath, explicitly framing it as a development outside the New Testament with novel theology about an \"eighth day\" for Christians—demonstrating Greco-Christian institutional and theological innovation.",
+    "quote": "And the first day is the Lord's day. And they even called it the eighth day. And they said and they began to develop a theology that's not in the New Testament that well the eighth day...Like the Old had seven. That's the Jews...And now we have an eighth day for Christians.",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "FEKkQgR5t14_3",
+    "text": "Mark frames the gospel as explicitly universal, to be preached to \"alle nationen\" (all nations), with deliberate narrative movements through Hellenistic territories integrating Gentiles into the messianic community—consistent with the book's thesis on ekklesia as Greek political institution.",
+    "quote": "markus füllt den begriff des evangeliums ganz klar universal markus 13 10 und 14 9 das evangelium soll alle nationen beziehungsweise in aller welt gepredigt werden",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "BVU5_rau6wI_3",
+    "text": "Discussion of Platonic dialogue structure appearing in rabbinic texts (Mishnah/Gemara), showing how Greek philosophical forms were adopted into Jewish institutional discourse, supporting continuity of Greco-institutional patterns.",
+    "quote": "the idea of the platonic dialogue shows up at rabbinic Judaism",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "eDya-DNHJaA_2",
+    "text": "Ovid's portrayal of Augustus includes deification, temple worship, cosmic apotheosis, and divine lawgiving—providing concrete evidence of Hellenistic political-theological institutions and practices.",
+    "quote": "he will rise to the sky as a god and be worshipped in temples...as giver of laws he will guide men's ways",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "ncQUJEbpZ9k_2",
+    "text": "Transcript traces Roman deification patterns (Julius Caesar and Augustus claimed descent from Venus) showing continuity of Greco-Roman political theology into the imperial era, supporting the book's thesis about early Christianity existing within established Hellenistic political-theological frameworks.",
+    "quote": "Julius Caesar and his Heir Augustus along with everyone in the Julio Claudia Dynasty forged particular explicit ties to Venus claiming dissent through her son Trojan hero Aeneas",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "qL0qP5HoBl8_2",
+    "text": "Dr. Ionescu's argument that \"Artemis is absolutely the OG version Mary\" evidences cultural-theological continuity from pagan Hellenistic religion into Christian theology, demonstrating the church's absorption and transformation of Greek religious categories rather than rupture from them.",
+    "quote": "Artemis is absolutely the OG version Mary...she really and Mary Saves the World she becomes the second Eve um she has priestesses like nuns all of that",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "wsXgyn36mO8_4",
+    "text": "Post-Temple rabbinic Judaism adopted Platonic dialogue methods (dialectic) in the Talmud, demonstrating Greek philosophical approaches infiltrating Jewish intellectual tradition during the formative Christian period, suggesting continuity of Greek intellectual methods across Jewish and Christian institutions.",
+    "quote": "rabbinic judaism where it's based on the talmud where it's back and forth dialogue what does the back and forth dialogue sound like that sounds like platonic... dialectic and that these are fictional conversations between rabbis of the past uh just like uh plato wrote these fictional conversations",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "7pwV5PyK-jo_2",
+    "text": "The Hellenistic king's role as mediator between the mortal and divine in performing religious ceremonies exemplifies the political-theological nexus central to Hellenistic kingship, supporting continuity of Greek political theology through the early Christian period.",
+    "quote": "\"the king was a go-between for the mortal and the divine\" when conducting ceremonial temple rites",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "7lXx9Fl3MA0_6",
+    "text": "MacDonald's discussion of how Luke structures Jesus's kingdom proclamation around political liberation from oppression (the Magnificat as \"not a praise of motherhood\" but a political document calling for God's intervention against foreign rulers) shows continuity with Greco-Roman political theology and liberation rhetoric.",
+    "quote": "the magnificat is a political document it is not a praise of motherhood...luke acts begins with the oppression of greeks then romans over the jewish people...the magnificat and the benedictus both are amazing texts...they set up luke acts as an epic of sorts",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "DMmr5ixaXbA_4",
+    "text": "Stanley identifies the Greco-Roman concept of *charis* (grace) as fundamentally a patron-client relationship term, providing linguistic-institutional evidence for how early Christian theology absorbed Greek political vocabulary: \"the Greek word is for that behavior of the Greek of the patron toward the people below him the clients Charis which is our word that's translated in our Bibles Grace\"",
+    "quote": "the Greek word...Charis which is our word that's translated in our Bibles Grace",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Zd6A6sNjcTw_6",
+    "text": "The argument that biblical theology deliberately adopts and adapts Greek philosophical frameworks (particularly Plato's) for expressing monotheism and divine hierarchy provides crucial precedent for how early church fathers would further develop Greco-Christian political theology around Jesus.",
+    "quote": "The recognition that this story may have dated as late as the early helenistic era along with the rest the pentat opens up new possibilities for comparative study...the Bible seems to be paying homage to its Inspirations",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "wixC10KQ8K4_0",
+    "text": "Philo of Alexandria's Hellenistic reinterpretation of Melchizedek using the Greek philosophical concept of the logos demonstrates how Greek frameworks shaped Jewish theology in ways that influenced early Christian thought—exemplifying the Greco-Christian interpretive patterns the book argues for.",
+    "quote": "the logos concept originated in Greek philosophy and here Pho is combining Greek concepts with an esoteric interpretation of Genesis in order to convey philosophical truth however pho's application of the logos to Jewish theology was highly influential among early Christians",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "wixC10KQ8K4_1",
+    "text": "The Epistle to the Hebrews applies a developed Melchizedek theology to Christ as an eternal heavenly priest, demonstrating how Hellenistic Jewish reinterpretations of scriptural traditions shaped early Christian Christology within a Greek conceptual framework.",
+    "quote": "the author of Hebrews assumes that his audience is already fully acquainted with a well-developed tradition in which melchisedek is not a dead historical character but an eternal priest in the Heavenly temple",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "9c6d04AaA5c_1",
+    "text": "Tabor traces the adoption of neoplatonic dualism by Christian theologians, showing how Greek philosophical frameworks fundamentally reshaped Christian theology—moving from an earthly, embodied focus to a heaven-focused spirituality that desacralized the body and sexuality. This demonstrates the deep integration of Hellenistic philosophical structures into early Christian thought.",
+    "quote": "I think it's coming from a trend that we call neoplatonism... It's a kind of a dualism where the earth is the place that we are, but it's kind of a prison, a lower place... that kind of uh worldview we call it cosmology is beginning to permeate the Christian theologians as well and with it comes an aestheticism a celibacy.",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Jor0oevcEK8_8",
+    "text": "Jewish religious institutions (synagogue zodiac mosaics) explicitly incorporated Hellenistic astrological ascent symbolism, proving that Greek institutional-theological language had penetrated Jewish worship by the early Christian period.",
+    "quote": "scenes on both mosaics share one important characteristic in both cases the scenes selectively reference the constellations of astrological ascent",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "iMlvjkeJI8o_0",
+    "text": "Tabor demonstrates the historical process by which Greek Platonic theology (immortality of the soul, compartmented Hades) merged with Hebrew resurrection theology to create early Christian theology, showing how Greek institutional and philosophical categories gradually came to dominate Christian theological frameworks.",
+    "quote": "the uh Jewish Christian view uh still keeps resurrection of the Dead which the Greeks don't have... even though it's a new body it still is a body... the ideas start with Greeks expanding their View of Hades they call it Hades it's equivalent to sheol... Hades has compartments... states of being that differ",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "iMlvjkeJI8o_2",
+    "text": "Tabor shows how early Christian theology shifted from Hebrew horizontal eschatology (resurrection at the end of time) to Greek vertical theology (immediate afterlife with judgment), demonstrating the actual historical process by which Greek categories displaced Hebrew eschatological categories in Christian thought.",
+    "quote": "all of that activity raising the Dead the new bodies and everything it all gets put up to heaven and people kind of forget the eschatology... well wait isn't the doesn't that all happen at the end",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "lKItbUWnymA_1",
+    "text": "Tabor's historical analysis demonstrates the wholesale replacement of Hebrew world-affirming theology with Hellenistic dualistic cosmology in early Christian thought. This provides concrete evidence supporting the book's central claim that Greco-Christian frameworks fundamentally transformed early Christian theology and institutions. Tabor specifically documents the shift from locative (Hebrew—things properly in place) to utopian/dualistic (Hellenistic—escape from evil world) religious worldviews, showing how Hellenistic philosophical categories infiltrated and reshaped Christian cosmology.",
+    "quote": "when you move to the hellenistic world and i'm not putting a date on it but i'm calling it the hellenistic world when you get into 300 200 100 b.c first century a.d... that view gets totally shattered in the hellenistic world... the early christians and jews superimpose upon this their their satanic ideas",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "kkBgaPXOsfI_0",
+    "text": "Tabor traces how perpetual virginity doctrine developed from neoplatonic/henistic dualism in 2nd-3rd century Church Fathers, demonstrating Greek philosophical ideas directly shaped Christian theology about Mary and holiness.",
+    "quote": "what's happening is I i'm going to call it neoplatanism or henistic dualism that's developing in the second third century >> where holiness is beginning to be described in aesthetic terms",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "oRXJEa1OzCI_0",
+    "text": "Early Christians interpreted the Eve narrative through the lens of Greek Pandora mythology, demonstrating the Greco-Christian interpretive framework central to the book's thesis. This conflation shows how Greek cultural categories shaped Christian theological discourse from the earliest period.",
+    "quote": "he thinks the eve story is actually read through um Pandora and this is for by early Christians and so this is one of the ways in which Eve turns kind of really bad in the midst of everything that she's conflated with Pandora she brings in sin just like Pandora opens the Box",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "2sZnADzQ2yo_1",
+    "text": "The documentary cites Nineveh tablets showing the Zakru festival sacrificed 70 unblemished lambs on the 14th of Nissan—the same date and designation used for Passover and Jesus's crucifixion—establishing institutional precedent for the dating and ritual structure of spring equinox observances.",
+    "quote": "on the 14th day, they offer 70 unblenmished lambs provided by the king for all 70 gods... the 70 lambs are to be sacrificed to each of the 70 gods of Omar.",
+    "source_chapter": 6
+  }
+]

--- a/sources/coverage/ch4_findings_redistrib_r1.json
+++ b/sources/coverage/ch4_findings_redistrib_r1.json
@@ -1,0 +1,482 @@
+[
+  {
+    "finding_id": "ngOxRGUO1Dg_0",
+    "text": "The transcript provides evidence that early Christian interpreters (like John of Patmos) were trained in Hellenistic-Mesopotamian intellectual traditions and applied these frameworks to Christian theology, supporting the thesis that Christianity requires a Greco-Christian rather than purely Jewish-apocalyptic model.",
+    "quote": "Could john of patmos have been indoctrinated with mesopotamian astrological precepts... well we know that daniel did it he became the supervisor of all of the babylonian astrologers and he surely preserved and passed on that wisdom to subsequent jewish scholars",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "wwCGbGdMPCc_0",
+    "text": "Dr. Bird and Derek argue that the Gospel of John was explicitly written for Greek audiences using Greek cosmological concepts (the Logos), not for Jewish audiences, supporting the book's critique that scholarly models focused on Jewish apocalyptic frameworks have overlooked the Greek institutional context. They note John 1:12-13 rejects genealogical claims that would resonate with Jewish readers, instead addressing a non-Jewish, Hellenized audience.",
+    "quote": "those first five ten verses of the Gospel of John take an ancient Greek cosmology and apply it to Jesus that's where we get that whole concept of the word was in the beginning was the word and the Word was God that is really powerful language for the church but it didn't come from Paul it didn't come from you know it came from the Greeks it didn't even come from the Jews",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "yM8bVT4xuHk_0",
+    "text": "McClellan discusses Mark 1:1-3 as appropriating imperial political language from the Priene inscription praising Augustus. Mark frames Jesus using the same \"good news\" (evangelios) language used for the emperor's coming into the world, directly supporting the argument that \"Son of God\" and related titles should be understood as Hellenistic royal terminology rather than purely theological language.",
+    "quote": "this verse is actually riffing off of an inscription that is praising Augustus called the Prine inscription where it Praises it talks about the good news the evangelios uh of the coming into the world of the god Augustus uh and so mark one is kind of ripping that off and kind of appropriating for Jesus this kind of political praise that is aimed at uh the emperor",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "d_dOhg-Fpu0_0",
+    "text": "Scholars' confirmation that Jesus's baptism by John the Baptist is historically attested and constitutes the beginning of Jesus's ministry. The transcript notes that Gospel writers felt compelled to reframe this event to avoid suggesting Jesus was John's disciple, indicating the baptism's historical significance and theological sensitivity—a fact supporting the book's treatment of baptism as a dynastic succession event.",
+    "quote": "Jesus was baptized by John the Baptist... the baptism of John the Baptist baptizing Jesus doesn't look like something early Christians would make up... it kind of goes against their tradition of raising Jesus up completely, and therefore, it may be historical.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "g2GFDG50s90_2",
+    "text": "Walsh argues that Gospel composition reflects engagement with Greco-Roman literary culture—genre expectations, Second Sophistic rhetorical tropes, and Greek novels—rather than primarily oral tradition. This reinforces the book's thesis that the Greek institutional and literary context is the formative influence on Gospel form and theology.",
+    "quote": "normalized the gospel authors within a scope of the production of literature that adheres to certain genre expectations that takes on you know certain characteristics representative of its location within the fabric of greco-roman literary production of the first and second centuries",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "2scp2vqtFF0_0",
+    "text": "Walsh describes Jesus's baptism in the Gospel of Mark as involving transfer of God's pneuma (divine substance), consistent with understanding baptism as a transfer of divine power and authority grounded in Greek philosophical concepts rather than purely Jewish apocalyptic tradition.",
+    "quote": "when in the Gospel of Mark, for example, the dove comes down during Jesus's baptism, the dove sends God's numa into Jesus.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "HKRYv7L04iI_0",
+    "text": "Walsh articulates the function of baptism in Mark as the moment Jesus becomes God's son, supporting the book's interpretation of baptism as a dynastic succession rite that confers divine status.",
+    "quote": "when he was baptized the Numa came down as a dove and made him God's son... It's something that's essential to Jesus becoming the son of God, at least in Mark",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "PMsvMKsDt4s_2",
+    "text": "Walsh identifies paradoxography—a Greco-Roman literary genre depicting wonders and amazing deeds in recently conquered imperial territories—as significantly shaping gospel production. Jesus's wonder-working in colonial Galilee fits this Greco-Roman genre, providing literary-cultural context absent from the book's analysis.",
+    "quote": "you have basically a Chronicle of amazing Deeds you know people in a far-flung place that was recently brought into the empire",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "PMsvMKsDt4s_3",
+    "text": "Walsh identifies subversive biography as a Greco-Roman literary precedent for the gospels, where protagonists succeed through wit and wisdom rather than power. Jesus in the gospels \"tends to get by sort of by his wits\" and \"negotiates time and space\" through parables and miracles, fitting this established Greco-Roman genre rather than traditional heroic biography.",
+    "quote": "that trajectory of literature actually already existed before the gospels if you think about it with figures like ESOP um or the Alexander romance... Jesus isn't your typical hero in the story uh he tends to get by sort of by his wits",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "0k_Sfn-j6KY_1",
+    "text": "Crane emphasizes that Greek education (paideia) was fundamentally based on learning to compose in Homeric style. This explains why any educated Greco-Roman writer—including early Christian authors—would naturally employ Greek literary patterns, supporting the thesis that Greek institutional/cultural context shaped early Christian composition at a foundational level.",
+    "quote": "the process of writing or school padeia in the ancient world was learning how to write Homer... if everyone who's educated learns how to write Homer it's not that big stretch to think that they would be also using Homer as a guide",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "4H0Y8Ztzrao_0",
+    "text": "Attridge emphasizes that the author of Hebrews came from a major Hellenistic urban center with Greek rhetorical training, supporting the thesis that Greek institutional context was central to early Christianity. He identifies Alexandria, Antioch, and Asia Minor as centers where educated Greeks would have access to philosophical and rhetorical training, consistent with the book's argument about Greek cultural primacy.",
+    "quote": "the author of this text was clearly a fairly well educated uh greek speaker the the greek is uh probably the best in the new testament... i think in any of the major urban centers of the greek east you would have found um the the the kind of rhetorical training",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "GDinKDicuLQ_4",
+    "text": "Baptism functioned as an initiation rite granting access to sacred meals (eucharist), mirroring mystery religion structures. This supports the book's interpretation of baptism as a Hellenistic institutional practice rather than purely Jewish purification.",
+    "quote": "for christians that would be a baptism which gives you access to a sacred meal aka the eucharist",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "Q_1MmYlXNUU_1",
+    "text": "Baptism is contextualized within mystery cult initiation practices, involving \"water magic\" or \"an ascent to heaven or being anointed with oil\"—practices that connect to Hellenistic royal and divine protocols rather than purely Jewish baptismal traditions.",
+    "quote": "secret doctrines... were only revealed to you after you underwent the initiation process which yes involves some sort of water right or water magic and in most cases but sometimes something more like an ascent to heaven or being anointed with oil",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "nCHrDf7JDgU_0",
+    "text": "The speaker establishes that baptism is not a Jewish religious practice but derives from pagan traditions, supporting the argument that Jesus's baptism should be understood within Greco-Roman cultural frameworks rather than Jewish religious tradition.",
+    "quote": "baptism does not show up in the old testament either it's not a jewish practice it is a pagan practice",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "tlGWmdKlcE0_0",
+    "text": "The transcript provides detailed evidence that ritual purification with water was a widespread Hellenistic practice across multiple Mediterranean cultures (Egyptian, Greek, Zoroastrian, Hindu) well before Christian baptism, supporting the book's argument that Jesus's baptism should be understood within a Greco-Christian rather than exclusively Judeo-Christian context.",
+    "quote": "bathing could be something you do just to stay clean and then bathing can be something you do to richly purify yourself in preparation for certain religious activities and it was pretty common throughout the mediterranean",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "-CoNBtCWYtw_1",
+    "text": "The speaker draws a structural parallel between Jesus's baptism (divine empowerment and voice declaration) and Telemachus being empowered by Athena to claim his father's authority. This supports the book's argument that baptism functioned as a dynastic succession rite, conveying transfer of authority through a Greco-cultural narrative framework.",
+    "quote": "\"the gospel of mark jesus is a young guy he's baptized by john the baptist and the spirit like a dove flies to him and says he hears a voice that says you are my beloved son\"—paralleled to Athena empowering Telemachus to act with his father's authority against rivals",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "-xL-QDgiTZ8_1",
+    "text": "The connection between baptism and the moment Jesus \"becomes\" Son of God (in Mark) aligns with the book's argument that baptism functions as a dynastic succession rite conferring royal status, even as the transcript frames this theologically rather than explicitly politically.",
+    "quote": "for Mark it's the baptism and it gives you um some kind of symbolism that I mean it also explains for any of the Gospel authors who may have been reading Paul or at least are in that kind of pollen tradition",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "9vnITYJ4ZQ8_1",
+    "text": "Carrier establishes that Christian baptism functioned as divine adoption—a transformative institutional act in Greco-Roman culture where status was established through baptismal declaration. This supports the book's argument that baptism should be understood as a dynastic succession rite operating through Greco-Roman adoption frameworks rather than exclusively Jewish contexts.",
+    "quote": "The Christian baptism was adoption by God. And so... this is fundamental to the faith because his thing is like okay Jesus is the firstborn so he's going to inherit the kingdom, right? So if we are brothers of Jesus, we also get to co-inherit the kingdom",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "C80zV5KbY2M_0",
+    "text": "MacDonald argues Jesus's baptism directly parallels Telemachus being empowered by Athena. The crisis begins the narrative (Israel in captivity / Penelope's suitors), the divine figure descends (Holy Spirit flying as a dove / Athena in sandals), and the beloved son is empowered to restore order—establishing baptism as a Hellenistic kingship/succession motif.",
+    "quote": "well jesus the gospels uh begin with a crisis namely uh israel is in captivity and the holy spirit comes upon jesus flying like a dove and heavenly voice says you are my beloved son...when you have beloved son think odysseus",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "C80zV5KbY2M_1",
+    "text": "The Transfiguration scene (Mark 9) mirrors Odysseus's transfiguration by Athena in the Odyssey. Both involve disguised royal figures revealed in glory, disciples/sons witnessing, offerings of honor, and secrecy commands. Jesus appears glorified with Moses and Elijah; Odysseus appears beautiful to Telemachus. This exemplifies Hellenistic royal protocol and glory language.",
+    "quote": "odysseus like superman is a man of power but he's disguised as a beggar...athena transfigures him into his real appearance...jesus is on a mountain with some of his most intimate disciples god transfigures him so that he appears in his glory...a voice from heaven says this is my beloved son obey him",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "EEro_BI3m1s_0",
+    "text": "Robinson discusses baptism as spiritual rebirth and transformation, where initiates are \"effectively born of a virgin\" through water ritual. This allegorical interpretation of baptism as transformative ritual supports the book's discussion of baptism as a dynastic succession rite.",
+    "quote": "when you have the water ritual you experience the baptism you are going through a birth but you are effectively born of a virgin",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "EEro_BI3m1s_1",
+    "text": "Robinson connects John the Baptist to the Levi/water tradition and the yoni (birth canal) symbolism, describing him as embodying a renewal and rebirth principle central to ancient religious initiation. This relates to the book's treatment of John in political-dynastic terms.",
+    "quote": "with John you've got a person who is carrying on the tradition of actually what the Hindus called the Yoni and it is the birth canal okay and so that is the image that the baptism is as is this place of renewal and rebirth",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "FTIum8FFQMo_2",
+    "text": "Derek interprets baptism through mythological water symbolism shared across Greco-Roman and Near Eastern traditions—water representing chaos, death, and the underworld (Leviathan, the dragon), with baptism as initiation into mystery theology. This supports understanding baptism within broader Hellenistic context rather than purely Jewish framework.",
+    "quote": "The body of water represent[s] death, chaos, disorder, the old age, uh, Leviathan, the dragon, right? All of these things I think are symbolic of water and Jesus is overcoming",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "GSEkSCV4fm0_0",
+    "text": "Cooney discusses baptism within Paul's theology as a magical practice requiring \"baptism and eating the Lord's Supper\" as ritual identification with Christ, analogous to magical acts performed by Isis for Osiris. This supports the dynastic succession interpretation of baptism.",
+    "quote": "baptism and eating the Lord's Supper which is the Flesh and the blood the the sacrament those two things and you're in Christ if you don't do these things you are not in Christ... those two things sound like magical acts almost like Isis has to do magical acts for Osiris",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "JOsGRR-vqUw_0",
+    "text": "The video draws a direct parallel between Jesus's baptism and Athena's empowerment of Telemachus in Homer's Odyssey. Both narratives involve divine empowerment confirming the subject's identity and authority. This supports understanding baptism within a Greek institutional context rather than purely Jewish tradition.",
+    "quote": "athena the goddess flies down to empower telemachus the son of odysseus why because he started to doubt he doubted whether he was the son of odysseus king of ithaca...once telemachu comes down and reminds him o telemachus you are the son of odysseus he is your father...he gets empowered",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "NV5ffzA_Jhc_0",
+    "text": "Lundwall traces baptism to ancient Hellenistic water-crossing rituals where water-immersion symbolizes overcoming death and rebirth, providing cultural context for understanding baptism's role in Greco-Mediterranean succession and initiation practices.",
+    "quote": "if you survived the flood you're going to survive the waters of death right...this eventually turns into baptism...we get reborn as a new Christian out of the waters",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "O1cxMlDgTa8_3",
+    "text": "Early Christian Epiphany traditions (January 6th) centered on baptism as divine revelation and epiphany rather than birth, suggesting baptism functioned as the primary moment of divine manifestation and legitimacy in Greco-Christian theology. Basilidean Christians celebrated \"the Epiphany of Christ\" on January 5th-6th, commemorating the baptism as the manifestation of divinity.",
+    "quote": "The Johannine Basil and Christians. If you read John by itself and you throw out the other three gospels, there's no birth scene... there only is the epiphany at the baptism. The baptism is born at the baptism... Even Origin says that the Basilans celebrated the Epiphany of Christ on this night [January 5th]. He says spending the whole night in readings and celebrating the next day.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "QJ4qY_0YXPw_1",
+    "text": "Baptism is analyzed as echoing Roman adoption rituals, consistent with the book's dynastic succession interpretation. The heavenly voice (\"You are my beloved son\") parallels the legal-ceremonial language of Roman heir designation.",
+    "quote": "At his baptism, a voice from heaven declares, 'You are my beloved son,' a scene that echoes the very language of Roman adoption rituals where a new heir was publicly affirmed and given the full rights of sunship.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "Rspshd_c7P0_0",
+    "text": "Lawson describes baptism as a \"transfer of prophetic authority from one figure to the next,\" supporting the argument that baptism functioned as a dynastic succession rite within a political-royal context.",
+    "quote": "when Jesus comes to John and is baptized, what's happening is a transfer of prophetic authority from one figure to the next",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "WEVrheGzIaQ_3",
+    "text": "The transcript discusses baptism as an initiation rite signifying succession and unity with a savior across Hellenistic religions (Mithras, Hercules, Osiris), supporting the book's interpretation of Jesus's baptism as dynastic succession within a Greek institutional context.",
+    "quote": "you would be initiated into the Hercules religion and instead of being baptized to indicate your unity with a savior you were done a lion may...you would be baptized in the blood of a bull",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "XlaqrYhw9oQ_1",
+    "text": "Price argues that baptism functioned as a mystery religion initiation rite, paralleling Mithraic and other Greco-Roman practices, and that participants understood themselves as participating in Christ's death and resurrection through the ritual. This supports the book's discussion of baptism within a Greco-Christian institutional context.",
+    "quote": "they used to way back wait to baptize people on Easter because it's a ritual reenactment of the the death and resurrection of Jesus which joined you to it and enabled you to participate in it... anybody initiated into the religion of Mithras participated in Mithras slaying of the cosmic bull which renewed everything",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "bhmVk-5IRJk_0",
+    "text": "The transcript describes how John the Baptist's disciples understood their baptism as preparation for \"the one to come,\" supporting the book's argument that baptism functioned as a dynastic succession rite transferring authority to Jesus.",
+    "quote": "they've been baptized but into John's baptism of repentance and Paul sets him straight he says well you know John the Baptist said you should believe in the one to come after me and that was Jesus",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "eWFTGKBd6J8_0",
+    "text": "Eisenman describes John the Baptist and the Qumran community's baptism practices as daily ritual immersion in preparation for apocalyptic war, requiring absolute purity so that holy angels could join their camps. This situates baptism within a political-institutional and dynastic succession context rather than purely spiritual purification.",
+    "quote": "they were preparing for the final apocalyptic war... they have to be perfectly holy and perfectly pure and therefore they have to bathe all the time because the Holy Angels were going to have to join their camps",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "gZ4KXqDyzHg_0",
+    "text": "MacDonald demonstrates that Jesus's baptism narrative parallels Telemachus's empowerment by Athena in the Odyssey—both involving divine affirmation of paternity (\"you are my beloved son\"), divine intervention by a female figure (Athena/Holy Spirit appearing as a dove), and subsequent empowerment to claim a father's kingdom. This establishes that Gospel authors were drawing on Hellenistic narrative conventions to frame baptism as dynastic legitimation.",
+    "quote": "you really are your father's son... And um so they make some plans of what to do next and then when she leaves she flies away and he recognizes her from the flight and um is empowered and immediately after his temptation goes out and declares that the kingdom of his father has come",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "iqEHysSPxuE_0",
+    "text": "Connor identifies extensive parallels between Greco-Roman ghost stories and Gospel resurrection narratives in Luke and John, providing evidence of Greco-Roman cultural influence on Gospel composition—directly supporting the book's Greco-Christian framework argument.",
+    "quote": "I was comparing uh ghost stories in the Greco-Roman world to the gospels of Luke and John and I thought wow that you know there are so many similarities here it is very very hard to imagine that this is simply a coincidence",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "opGVsetLejY_1",
+    "text": "McDonald interprets Jesus's baptism through a Homeric hero-cycle framework, where divine voices confirm a young destined figure's royal identity and he faces trials to prove worthiness for kingship. This parallels the Q tradition in which the Spirit confirms Jesus as God's son, kingdoms are offered to him, he refuses them, then claims the kingdom—aligning baptism with Greek royal succession protocols.",
+    "quote": "in the Q document the Holy Spirit or the spirit of God flies to Jesus like a dove he a Heavenly voice says you are my beloved Son then the devil offers him the kingdoms of the world and Jesus refuses it because he knows now that he's God's son he's responsible for God's Kingdom... young men often uh like Gil gamish uh have to face a dragon or a challenge early in their careers to show them their metal uh and that they're worthy of being a hero",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "peNQQnJ_pJc_1",
+    "text": "Pagels situates early Christian baptism within Hellenistic mystery religion initiatory structures, citing Church Father Tertullian's reference to a 5-year initiation process before accessing secret teachings, supporting understanding of baptism in Greek institutional frameworks.",
+    "quote": "the church father Tertian said they had a 5-year initiation process before you could enter into the secrets",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "peNQQnJ_pJc_2",
+    "text": "Derek identifies parallels between Dionysus epiphany (January 5-6) featuring water-to-wine transformations and Gospel of John's wedding at Cana, suggesting early Christian adoption and adaptation of Greco-Roman religious practices in shaping gospel narratives and sacred calendars.",
+    "quote": "Pliny the Elder... points out that this is the same day that the epiphany of Dionysus is celebrated and they actually have a festival... where the epiphany of the God Appears and these streams... transform into wine and then you get this interesting gospel we call the Gospel of John and it has this wedding at Cana",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "rr_0QWA-8Yk_1",
+    "text": "Barker's extensive discussion of Gospel authors as educated practitioners of Greek rhetorical tradition (specifically oppositio in imitando) supports the book's emphasis on Greco-Christian framework and rhetorical sophistication shaping early Christian texts.",
+    "quote": "oppositio in imitandando is is similar in that regard. They didn't use that term rhetorically in antiquity, but they did it. So, they turned things inside out... if you were very highly educated was to take something and turn it inside out.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "tf7BFokUx1M_2",
+    "text": "Hanson discusses baptism in terms of dynastic succession and symbolic anointing, connecting it to Elijah's anointing role and explaining plausible reasons for its invention within a Greco-Roman political context.",
+    "quote": "you could have a guy who baptizes...to a gentile could be considered a symbolic anointing uh of their of the Messiah Jesus this is a very specific event that you can very clearly see some reasons why they would invent this kind of a story",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "2S9Dfrbrwm8_0",
+    "text": "Tabor describes Jesus's baptism as a \"transfer of prophetic authority from one figure to the next,\" consistent with the book's interpretation of baptism as a dynastic succession rite involving succession from John the Baptist to Jesus.",
+    "quote": "when Jesus comes to John and is baptized, what's happening is a transfer of prophetic authority from one figure to the next",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "DbrufyTudxo_0",
+    "text": "Tabor documents that John the Baptist and the apocalyptic community practiced immersion baptism specifically as initiation into the movement, not merely for ritual cleansing—providing historical context for understanding baptism as a formative rite in the wilderness setting where John and Jesus operated.",
+    "quote": "they also baptized that's the Christian word dipped in immersion not for Jewish rights of ritual cleansing but to initiate you into the movement",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "WlUCYM3TH9I_2",
+    "text": "Tabor's description of Jesus's baptism as a \"prophetic anointing\" and commissioning event aligns with the book's treatment of baptism as involving dynastic/royal anointing protocols, though framed within a Hebrew rather than explicitly Greco-Hellenistic context.",
+    "quote": "It's Isaiah 42... a prophetic anointing... you're the guy I'm going to pour the spirit out on and used as my messenger",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "UcrWgvkTujM_0",
+    "text": "Biglino frames John the Baptist's baptism as a political-institutional practice, describing baptism as \"the rite of entry into the army\" and John as organizing fighters. While his specific interpretation emphasizes military recruitment rather than dynastic succession, it reinforces the book's argument that baptism was a political-institutional Greek rite preparing for Jesus's takeover of power.",
+    "quote": "He needed cutthroats, he needed people willing to fight... immersion that is the rite of entry into the army... John the Baptist was preparing the way for the one who would then have to take command, that is of Jesus, and he was preparing an army of fighters",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "fyC60YjR1oE_0",
+    "text": "Baptism as a Hellenic rite of succession: Jesus's baptism parallels the Telemachus narrative (Odyssey 1), where Athena appears as a bird to signal paternity and divine succession. This frames baptism within Greco-Roman institutional ritual rather than exclusively Jewish prophetic tradition.",
+    "quote": "I argue that not only is the baptism of jesus similar to the uh enthronement of or the announce the unction of a prophet but it's also similar to young talemkus finding out who his father is because athena flies to him like a bird and flies away like a bird",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "gxXlVV8oW8U_1",
+    "text": "Zinner argues that Josephus uses \"Christ\" as a personal name rather than a messianic title when addressing his Greek/pagan audience unfamiliar with Jewish concepts. He parallels this to how \"Buddha\" shifted from title to personal name in Buddhist traditions, explaining how titulature functioned in Hellenistic contexts.",
+    "quote": "he's using it as a personal name not as a title so it's not hamashiach right rendered in greek which is a title the messiah to translate this be translated as christ as a personal name... buddha was originally a title he was buddha his name was siddhartha but with time right buddha actually becomes a personal name among his his the buddhists use this now as a personal name and this is what happened in the early christian movement",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "5-yNa34Sfx0_1",
+    "text": "Litwa emphasizes that ancient Greeks and Romans had a different framework for assessing plausibility than moderns. He notes Philostratus's Life of Apollonius—a Greek work contemporary with the gospels—presents miracles comparable to Jesus's, suggesting the gospels should be read within Greco-Roman cultural assumptions about what was credible.",
+    "quote": "\"at least one very sophisticated greco-roman author namely philosophers is wants us to believe that these things happened\" (referring to miracles similar to those in the gospels)",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "ec8Tpp2rjc0_1",
+    "text": "Ehrman emphasizes that Jesus in Mark's Gospel possessed extraordinary invested institutional authority—authority to cast out demons, teach, heal, and forgive sins—consistent with the book's framework of Jesus as a politically authorized figure.",
+    "quote": "Jesus clearly has uh enormous powers and he's um he's he's been invested with authority that's not available to most people to just about anybody in the gospel of Mark the authority to cast out demons the authority to teach the authority to heal to to forgive sins",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "mNv5JEoBcqI_2",
+    "text": "Burke discusses Dennis McDonald's identification of Homeric parallels in Gospel accounts, including the anointing episode where the woman's action echoes Homer's euroclea (meaning \"fame far and wide\"), demonstrating that Gospel writers intentionally wove Greco-Roman literary allusions into their narratives.",
+    "quote": "in the gospel Mark... when Jesus's feet are being anointed... she recognizes her master... well okay so let's go back to this Odyssey Odysseus's feet are being rubbed by uraclaya... she recognizes her master... her name is your claya the name euroclea means Fame far and wide what Jesus told the woman that's rubbing her feet that should what she did today will be told far and wide it's almost as if it's a pun",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "o8co7YYxnf8_3",
+    "text": "Hillman references Dennis McDonald's work demonstrating direct narrative parallels between Homer's Odyssey and the Gospel accounts (Odysseus/Cersei parallels to Jesus/demoniac incidents in Mark). This provides evidence that Gospel narratives are structured on Greek literary traditions, supporting the thesis that early Christianity embedded itself within Greco-Roman cultural frameworks rather than remaining within purely Jewish categories.",
+    "quote": "so we have the sequence of events is lining up here… the giant ask Odysseus's name… Jesus asked the demoniac his name… Odysseus answers nobody is my name… the demoniac answers Jesus Legion is my name… it's the same story being retold through a different lens through a different time through a different character Odysseus and Jesus",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "wKChK3H5i3Q_0",
+    "text": "MacDonald provides specific textual evidence that Mark's anointing narrative (14:3-9) deliberately imitates Homer's Odyssey Book 19. He distinguishes between royal anointing (χριστός/christos—anointing someone to be king or prophet) and burial anointing (the humble anointing of a corpse), establishing that Mark's anointing of Jesus is embedded in Greek literary and institutional frameworks rather than Jewish royal practice.",
+    "quote": "The woman who anoints jesus for his burial in mark surely imitates the famous homeric nypdra or washing by eurocley odysseus's nurse who recognized the scar on his thigh while washing his feet",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "wKChK3H5i3Q_1",
+    "text": "MacDonald argues that Mark signals sophisticated Greek literary knowledge by encoding Euroclea's name meaning (fame/renown) into his narrative structure—the unnamed woman achieves widespread fame precisely because Mark activates his Greek-educated readers' recognition of the Homeric parallel.",
+    "quote": "Mark is expecting his reader to know that she's going to have renowned far and wide because that's what the name euroclea means... mark is not hiding his imitation",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "hcaLWLMdhZg_3",
+    "text": "McClellan recommends Michael Bird's *Jesus Among the Gods: Early Christologology in the Greco Roman World*, noting it \"covers a variety of different uh texts and a variety of different approaches to understanding Jesus's relationship to God\" and makes \"a case that there is um that there was a concern for the ontological relationship of Jesus to God already by the time of the composition of the gospel of John.\" This reinforces both the Greco-Roman context (Chapter 3) and Johannine theological development (Chapter 4).",
+    "quote": "Michael Bird's book, Jesus Among the Gods: Early Christologology in the Greco Roman World... it's making um a case that there is um that there was a concern for the ontological relationship of Jesus to God already by the time of the composition of the gospel of John",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "--MKyxX907k_1",
+    "text": "McDonald demonstrates that Mark deliberately constructs Jesus as an \"alternative founding myth\" comparable to Virgil's Aeneas, motivated explicitly by anti-Roman political sentiment. This supports the book's argument that Gospel theological claims about Jesus and Kingdom should be understood as Greco-Roman political-theological constructs rather than purely Judeo-Christian ones.",
+    "quote": "Virgil's Aniid is understood to be the dominant founding myth of the Roman Empire, the early empire. And Mark is competing with that...it's informed by a hostility for Rome and it's expressed in an alternative founding myth.",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "4AflezmCMqY_2",
+    "text": "Lumpkkey demonstrates through multiple examples (Ifigenia/Jephthah, Jason/Medea parallels in Judges) that biblical narratives were composed using Greek literary patterns and mythological frameworks, supporting the book's argument that understanding Jesus traditions requires attention to Greek institutional and literary conventions rather than exclusively Judaic categories.",
+    "quote": "And then judges then you have Samson... you have the same story and the bane of both people both heroes are women",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "B8GCW2AVAF8_1",
+    "text": "Tripp demonstrates that first-century Hellenistic quotation conventions valued theological reinterpretation and paraphrasing over verbatim reproduction—\"that's you being a good teacher is playing with the language to unpack its meaning.\" This supports understanding John's construction of Jesus's Christological claims (titles, kingdom language, theological identity) as developed through Greco-Roman rhetorical conventions, not literal historical record-keeping.",
+    "quote": "playing with the language to unpack its meaning so if you come to believe for example that uh Jesus was resurrected after three days then it's your job to unpack any sayings that he had that point in that direction and to rephrase them in a way that clarifies them so it's it's also a different ethic on on verbatim recall",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "YYUUx7wK0J4_0",
+    "text": "Pagels shows that gospel authors strategically constructed narratives to position the Christian community institutionally, particularly shifting blame from Romans (who actually crucified Jesus) to Jewish opponents for political safety. This supports the book's argument that \"Kingdom of God\" and Christian theology should be understood as fundamentally political-institutional rather than purely spiritual categories.",
+    "quote": "these people followers of jesus... didn't want to be seen as revolutionaries because it was so dangerous so they basically told the story of the death of jesus in a way to sort of say well okay romans did it but they it was the jews who instigated the whole thing",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "_rtPgyMcpNo_3",
+    "text": "Lambert emphasizes Matthew's literary construction of Jesus as a new Moses figure, arguing this reflects intentional authorial crafting rather than historical memory—consistent with understanding Jesus through Greek literary convention and royal-theological archetypes.",
+    "quote": "Matthew's rewriting a Moses story having Jesus the central figure... they are purposely crafting Jesus to look like Moses... that is literary that is instructive that is that is the fanciful pin of the author",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "pMf40mX9w_k_3",
+    "text": "Matthew deliberately removes distinctive Homeric parallels from the Gerasene demoniac story (removing the single demoniac, the sailing, the name-exchange, the departure request) to shift Mark's mythological narrative into biographical-historical form.",
+    "quote": "Matthew retells the story and removes almost all of The Telltale traits that are unusual in its stories...in my view what Matthew has tried to do intentionally or not is to remove the most most telling elements of the story that make it a Mythos a myth to make it into a bios",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "sytOWPtlDAs_3",
+    "text": "The Gospel of Matthew directly adopted the similitudes' imagery of \"the son of man sitting on the throne of his glory\" to describe Jesus's final judgment role, demonstrating that early Christians drew on pre-existing Greco-Jewish apocalyptic concepts and royal theology rather than developing Christology independently.",
+    "quote": "the son of man sitting on the throne of his glory is an idea unique to the similitudes\" and Matthew's use: \"at the renewal of all things when the son of man is Seated on the throne of his glory you who have followed me will also sit on 12 Thrones judging the 12 tribes of Israel",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "tozott4Q5ok_1",
+    "text": "The detailed analysis of the Gospel anointing narrative as literary imitation of Homer's Odyssey demonstrates that Gospel authors drew directly on Greek epic sources rather than exclusively Jewish tradition. This shows Gospel theology was constructed through Greek cultural and literary frameworks, supporting the thesis that a Greco-Christian interpretive lens is essential.",
+    "quote": "the woman who anoints jesus for his burial in mark surely imitates the famous homeric niptra or washing by uraclia odysseus's nurse who recognized the scar on his thigh while washing his feet in odyssey 19... mark is not trying to disguise his imitation he's advertising his imitation and wants to show that the episode about jesus is actually superior to the one in homer",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "ysKUelnSpls_2",
+    "text": "Scholar Dennis McDonald identifies direct Homeric literary parallels in Mark's Gospel, demonstrating that Gospel authors deliberately merged Greek literary narratives (Homer's Odysseus cleansing his father's house) with Jewish sources to construct their temple cleansing accounts, providing evidence that Gospel construction must be understood through Greco-Christian literary frameworks.",
+    "quote": "the author of mark who was obviously familiar with both saw these two things the cleansing of his father's house and the cleansing of the jerusalem temple and had this epiphany a way to merge the two",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "5zZchadJDM0_0",
+    "text": "MacDonald argues that the earliest recoverable layer of the Gospel of John—the \"Dionysian Gospel\"—portrays Jesus as a divine donor deity comparable to Dionysus, giving wine, life, and eternal pleasure. He notes that ancient Christian readers (Clement of Alexandria, medieval poets) explicitly recognized these Dionysian parallels to Jesus's theological significance.",
+    "quote": "ancient readers recognize that the jesus of the fourth gospel is quite a different character than the jesus of paul or the synoptics and in fact they saw similarities between jesus and the fourth gospel and the god dionysus... jesus is from the beginning to the end a donor deity much like demeter in giving grain or dionysus in giving wine and pleasure",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "xddZbf6EE7k_0",
+    "text": "MacDonald reveals that the Q document imitates Homer's Odyssey, demonstrating Greek epic literary influence in the earliest Gospel source and directly supporting the book's thesis that Jesus tradition should be understood through a Greco-Christian framework.",
+    "quote": "the author of the logo of Jesus already is imitating the Odyssey",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "F82JssUTYzg_1",
+    "text": "The professor traces how Johannine Christianity underwent institutional divisions and schisms along Christological lines, showing \"four different stages of a church with different kinds of divisions happening and therefore different kinds of Christianity developing due to these divisions,\" illustrating the political-institutional dimensions of early Christian sectarianism relevant to the book's framework.",
+    "quote": "they're clearly written by the same school of early Christianity...You can almost see four different stages of development...Early churches also seem to split a lot...Four different stages of a church with different kinds of divisions happening and, therefore different, kinds of Christianity developing due to these divisions",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "GvXDKhP4uck_1",
+    "text": "MacDonald's argument that \"the gospels need to be seen as competitors not collaborators on the grand stage of civilization\" engaging with Homeric epics and arguing with each other suggests the Greek literary-institutional context was fundamental to how early Christian communities formulated theology and identity.",
+    "quote": "the gospels need to be seen as competitors not collaborators and on the grand stage of civilization and not merely as private cultic self-help literature... they're arguing with each other that's what this book that's coming out from me uh my next book synoptic Epistles in homeric epics... the clash of the Gospel authors with each other about homeric epics",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "VNLR_d2PAlY_4",
+    "text": "Walsh identifies the patronage system (Luke's patron providing resources and library access) as foundational to gospel composition, illustrating the institutional Greco-Roman structures supporting early Christian literary production.",
+    "quote": "he has a patron you have to recognize your Patron there is no way somebody just bankrolled you to like write this thing...probably because like this Patron had a library that this person was allowed to use like thanks for the resources appreciate the cash you can trust me this is a good one",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "HlLpAw-W1-0_3",
+    "text": "Biglino notes that major Church Fathers (Justin, Clement, Origen, Augustine, etc.) knew an alternative Gospel manuscript reading where Jesus is \"begotten\" as son of God at baptism rather than merely receiving God's pleasure. This evidences Church Fathers' awareness of multiple interpretations of Jesus' divine sonship claims.",
+    "quote": "Some codices and some manuscripts and many Church Fathers such as Diognetus, Justin, Clement, Origen, Hilary, Augustine, and others don't read 'I am well pleased with you,' but rather 'I have begotten you today.'",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "BqILLv1Dvl0_2",
+    "text": "Price discusses specific literary dependencies showing the Gospels were composed in Greek literary traditions: Mark parallels Homer's Iliad/Odyssey, Luke parallels Virgil, and John parallels Euripides' Bacchae (per Dennis McDonald's scholarship). This demonstrates the evangelists intentionally shaped Jesus narratives using Hellenistic literary conventions for Greek audiences—direct evidence of Greek institutional and cultural mediation of Christian theology.",
+    "quote": "dennis r mcdonald called luke and virgil uh where he traces a bunch of stuff i never noticed uh between the two and he's done the same thing with uh mark and the iliad and the odyssey and with uh john and the the bachai of euripides... it it's a lot more hellenistic in the new testament than anybody ever realized",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "o8co7YYxnf8_3",
+    "text": "Hillman references Dennis McDonald's work demonstrating direct narrative parallels between Homer's Odyssey and the Gospel accounts (Odysseus/Cersei parallels to Jesus/demoniac incidents in Mark). This provides evidence that Gospel narratives are structured on Greek literary traditions, supporting the thesis that early Christianity embedded itself within Greco-Roman cultural frameworks rather than remaining within purely Jewish categories.",
+    "quote": "so we have the sequence of events is lining up here… the giant ask Odysseus's name… Jesus asked the demoniac his name… Odysseus answers nobody is my name… the demoniac answers Jesus Legion is my name… it's the same story being retold through a different lens through a different time through a different character Odysseus and Jesus",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "B3dz9PY1Y10_2",
+    "text": "McDonald and Miller argue that early Christian texts—like Virgil's Aeneid—should be understood as myths of cultural and political identity (\"myths of Origins\") shaped through engagement with dominant Greek literary traditions. This supports the thesis that early Christianity positioned itself within Hellenistic political-theological frameworks.",
+    "quote": "the gospel of Mark and Luke acts are not intended to be historical they're intended to be mey of Origins... like Virgil's anid that's a Mythos of the early Roman Empire... the reader is not expected to see them as historical but as culturally engaging",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "OoVnEqNRXGY_2",
+    "text": "Gospel narratives, particularly Mark's Passion account, were substantially reformulated to present Jesus as politically accommodating to Roman rule and to exonerate Roman authority, demonstrating that Gospel theology was deliberately shaped to function within the Greco-Roman political-institutional framework.",
+    "quote": "mark rewrote the Jesus story to say oh no no it was a frame-up he was he posed no danger wrong Pilate exonerated him it was those Jews... mark rewrote the story to sanitize Jesus in Roman eyes",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "PrPoP3e-SAo_2",
+    "text": "The discussion of how social identity markers shifted across gospel compositions—from Q's Jewish focus to Mark's Greco-Roman focus to Matthew's synthesis—suggests that understanding early Christian theology requires tracking the shift toward Greek institutional and cultural frameworks.",
+    "quote": "the social identity of the q author...its concern is on making the law more compassionate...when you get to the gospel of mark...the social identity of the author becomes clearer...now the social identity markers shift from one document to the next",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Rspshd_c7P0_4",
+    "text": "Lawson argues that Mark systematically rewrote the Jesus narrative to obscure its political-royal dimensions, denigrating the family members (James, Simon, Judah) who actually led the movement after Jesus's death, and transforming the Hebrew name \"Judah\" into the Greco-Roman \"Judas\" as a literary attack on the original political messianism.",
+    "quote": "when Mark rewrote the story he changed it all so that he insulted the Jesus's family... Jesus's brothers took over James took over after Jesus and then Simon took over after James and then Judah took over after Simon... calling the person who gets Jesus killed is it's Judas it's almost like a jab... the whole rewrite the New Testament is a reversal of everything",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Wu2anuMfOJg_2",
+    "text": "Tabor demonstrates how early adoption theology (Jesus designated as Son of God at baptism) became classified as the \"adoption heresy\" by fourth-century church fathers—supporting the book's argument that institutional Christianity reinterpreted and rejected earlier Greco-Christian frameworks in favor of incarnational orthodoxy.",
+    "quote": "it's adoption first, which is the big heresy of the fourth century, because Jesus is the one who hears 'You are my beloved son' at the baptism",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "YwUfy26-alA_8",
+    "text": "Christian adoption theology conflating baptism with deified son-becoming, paralleling Dionysian Epiphany festival structure (January 5-6)—establishing baptism as Hellenistic political-theological succession rite, not purely Jewish immersion practice.",
+    "quote": "early Christians celebrated the adoption of God which is birthing a new son technically through adoption at baptism which is why they conflated birth narratives with the adoption in baptism",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "i3RQqezynLQ_0",
+    "text": "Price argues that the Eucharist derives from Hellenistic mystery religions (Dionysus and Osiris) rather than Jewish tradition, providing concrete evidence that core early Christian rituals reflected Greek cultural frameworks consistent with the book's Greco-Christian thesis.",
+    "quote": "it comes from an agriculturally based uh mystery religion like all the mystery religions... the most prominent examples being dionysus and osiris... both had sacramental meals in which one uh ate bread as the body of the god... it makes no sense whatever in a jewish or christian context",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "nuLs65uWE5U_4",
+    "text": "MacDonald argues that Luke structures the Jesus narrative using Homer's Iliad model, where Jesus's death anticipates the fall of the city (Jerusalem), positioning the gospel as Hellenistic political-theological narrative. This shows early Christian theology mirrored Greek epic structures for legitimizing political claims.",
+    "quote": "mark is the first person to have a full-blown narrative of the life of jesus and he's writing in the aftermath of the jewish world and he's identifying the cause of the jewish war with the inability of israel to accept the teachings of jesus",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "sBnRe-cs_TY_1",
+    "text": "Price's discussion of Oder's work on Mark as a theatrical performance written within greco-roman dramatic conventions supports the book's framework of understanding early Christian texts through Hellenistic institutional and cultural contexts. The emphasis on theatrical staging, architectural design of greco-roman theaters, and performance conventions locates the gospel's origins within Greek rather than purely Jewish religious frameworks.",
+    "quote": "she has done all kinds of res uh research uh about the the set up of ancient um theaters and so forth... she explains how each scene she has isolated from the prose gospel must have been staged and in what part of the theater",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "M9Fa8Ci6rGs_2",
+    "text": "Tabor provides detailed evidence for identifying textual interpolations (like the trinitarian formula added to Matthew 28 by later scribes), demonstrating methodology for distinguishing earliest sources from later theological layers—supporting the book's work on identifying early vs. late textual strata.",
+    "quote": "90 of the things put in were to push this trinitarian view of uh Jesus as God so the scribes are going back through doctoring up the manuscripts",
+    "source_chapter": 6
+  }
+]

--- a/sources/coverage/ch5_findings_redistrib_r1.json
+++ b/sources/coverage/ch5_findings_redistrib_r1.json
@@ -1,0 +1,248 @@
+[
+  {
+    "finding_id": "jHu8meAM_-g_1",
+    "text": "Early Christian eucharistic meals followed the organizational structure and cultural patterns of Greco-Roman associations and banquets, supporting the Greco-Christian interpretive framework over purely Judeo-Christian models.",
+    "quote": "it is now widely held that early Christians organized their community meals along the lines of Greco Roman dining, adapting the format to meet their own ritual needs... the origin of early Christian meals is not to be found in any one type or originating event, but rather in the prevailing custom in the ancient world for groups to gather at table.",
+    "source_chapter": 1
+  },
+  {
+    "finding_id": "C-MZV03wsFM_2",
+    "text": "Tabor argues Paul derives his authority to demand obedience from his mystical experience of directly encountering Christ in heaven, grounding authority claims in cosmic-spiritual legitimacy rather than traditional institutional channels. This supports the book's framework about Hellenistic models of political-spiritual authority.",
+    "quote": "he even has language and tone that presumes that he has the right to demand obedience and it seems to be based upon perhaps this aesthetic experience that he had",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "VzWdFgWH3Xs_3",
+    "text": "Tabor discusses Enochian Judaism mysticism in the Dead Sea Scrolls as providing context for understanding Paul's mystical theology, noting parallels in language of exaltation and cosmic transformation (\"I am sitting among the gods I've been exalted I'm above all the Elohim\")—relevant to understanding the Hellenistic-Jewish milieu of the Second Temple period.",
+    "quote": "the Dead Sea Scrolls were not even discovered and that's where we really find some of the mysticism particularly in the teacher hymns...he talks about I am sitting among the gods I've been exalted I'm above all the Elohim",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "yomIpReivsI_3",
+    "text": "Tabor presents extensive evidence that ascent to heaven was \"a quintessential Hellenistic thing,\" surveying texts like Enoch, Ascension of Isaiah, Plato, and Cicero. This establishes the Hellenistic religious context essential for understanding early Christian cosmology and theology.",
+    "quote": "Paul's Ascent to Paradise which is a quintessential Hellenistic thing to do is to see the cosmos as the place from which you want to rise up and move beyond the Aeons and the levels of Heaven",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "ayuwPvqo_0I_2",
+    "text": "Paul, a key figure in early Christian institutional development, came from Tarsus, a major center of Stoic philosophy, and directly engaged with Stoic and Epicurean philosophers in Athens, demonstrating his immersion in the Greek intellectual world and the Greco-Christian intellectual continuity.",
+    "quote": "Paulus kannte sie mit Sicherheit ein zweites Argument ist dass Paulus aus der Metropole kommt... Tarsus war auch ein Zentrum stoischer Philosophie",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "fp_NNoCe2L0_0",
+    "text": "Biglino emphasizes that the Gospels were written in Greek in a Hellenized environment saturated with Platonic philosophy, fundamentally shaping the meaning of \"Son of God\"—which originally referred to someone with a specific mission but acquired theological meanings through Greek philosophical influence.",
+    "quote": "It's clear that the Gospels were written in the Hellenistic era, in Greek, and primarily under the influence of Pauline thought... They were also written in a Hellenized environment, one that had already absorbed Platonic philosophy and therefore possessed concepts that did not belong to the Jewish world... We have already said many times that without Platonism, Christianity would not exist.",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "-I5opAIthpc_0",
+    "text": "Bennett discusses how Paul reinterprets baptism through mystery religion mysticism, transforming it into a claim about dying and rising with Christ—i.e., deification through participation. This parallels and strengthens the book's argument that \"resurrection as political-theological legitimacy claim\" operates in a Greco-mystical rather than purely Jewish framework.",
+    "quote": "Romans chapter 6 verses three through five... all of us who were baptized into Christ Jesus were baptized into his death we were therefore buried with him through baptism into death in order that just as Christ was raised from the dead through the glory of the Father we too may live a new life... this sort of mystical identification with Christ and the parallel interaction of death and rebirth or new life between the devotee and the deity",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "-I5opAIthpc_1",
+    "text": "Bennett catalogs Greek mystery-religion vocabulary pervasive in Paul's epistles: *mysterion* (27 times in NT, 21 by Paul), *teleioo* (perfection/maturity), *nepios* (infants/babes newly initiated), and *apotheosis* (witnessing/beholding). This lexical analysis strengthens arguments about Greek theological and institutional framing of kingdom theology.",
+    "quote": "the terminology that is used that you find just swimming throughout the Pauline epistles where that converges with the mystery religions the very word mysterion in Greek that's used 27 times in the New Testament 21 of which are by Paul",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "-I5opAIthpc_2",
+    "text": "Bennett and the host discuss *theosis*—the initiate's transformation into a divine being through mystical identification with the dying-rising god, paralleling Paul's baptismal theology of being \"reborn\" and \"made perfect.\" This directly supports the book's claim that resurrection functions as deification and legitimacy.",
+    "quote": "the Orphic Dionysus according to golden tablets... the initiate being reborn... as Dionysus was thrice born... the devotee has undergone what the god himself underwent... theosis becoming divine... much as what you find in the ancient egyptian cult",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "-I5opAIthpc_4",
+    "text": "The discussion of realized eschatology in the Gospel of Thomas and Paul (Romans 8, the heresy of Hymenaeus and Philetus) shows mystical-Gnostic reinterpretation of resurrection as already accomplished through initiation. This supports the book's argument that resurrection is a theological and mystical claim, not a temporal one.",
+    "quote": "Gospel of Thomas saying 51 and 113... Jesus says look around the resurrections already occurred you just can't see it... in Romans 8 you have he who those he justifies he'll sanctify... if you are getting justified you're gonna end up glorified... justified as initiated which means you're resurrected you're crucified with Christ you are resurrected with Christ already",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "2xrtEKOcyDI_1",
+    "text": "Derek observes Paul's systematic spiritualization of Jewish concepts—circumcision, baptism, Sabbath, dietary law—converting them from literal/fleshly practices to spiritual principles, supporting the thesis that Greek theological frameworks displaced Jewish ones in early Christianity.",
+    "quote": "he takes circumcision which is fleshly and makes his spiritual he takes baptism which is literal water he makes it spiritual he takes the Sabbath and he makes it from a literal day - every day it's spiritual",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "6CK1s04dU70_1",
+    "text": "The speaker argues that early Christianity appropriated Greek mystery terminology (mysterion) and initiation frameworks, showing that Greek institutional-liturgical concepts were central to how early Christians understood their faith—supporting the thesis that Greek frameworks, not Judeo-Christian ones, shaped early Christianity's self-understanding.",
+    "quote": "the greek word a secret revealed only to alkalize who had been ritually initiated the very word mystery a greek word held deep liturgical connotations central to ancient religious practices",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "9aD-SrvAONY_2",
+    "text": "McDonald identifies Acts 16 (Paul's imprisonment and earthquake-enabled escape) as a deliberate literary imitation of Euripides's Bacchae, with structural parallels including supernatural earthquake triggered by singing/praying, prison break, and conversion of the jailer. This demonstrates that Acts employs Greek dramatic narrative structures to frame theological claims about divine authority—a direct example of how early Christian narratives adopted Greek institutional and cultural forms.",
+    "quote": "midnight Paul and Silas were singing Psalms and praying to God...suddenly there was a great earthquake such that the foundations of the prison were shaken the doors immediately flew open and the restraints all fell off",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "B5d3ruUp0yE_1",
+    "text": "Dr. Bird argues that Paul's soteriological models derive from Greco-Roman religious traditions (Isis, Mithras, Artemis cults) rather than Jewish precedents, stating that \"all but one [of the salvation models] are Greek or Roman they're not Jewish.\" This evidences that early Christian theology of Jesus's death and resurrection was fundamentally shaped by Hellenistic theological categories rather than exclusively Jewish frameworks.",
+    "quote": "if you look at those models of salvation all but one are Greek or Roman they're not Jewish so spot on on that so that's an import that's a Hellenistic import that I think is interesting",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "_2K-mFBa-78_4",
+    "text": "Kloppenborg identifies \"Hypsistos\" groups—small, gender-inclusive associations devoted to \"the Highest God\"—as organizational parallels to Christ groups, suggesting Christ groups fit seamlessly within broader Hellenistic religious associative patterns rather than representing a unique Jewish innovation.",
+    "quote": "hypsistos groups tended to be gender inclusive they tended to be relatively poor... they also tended to be relatively small of 25 to 35 persons... there's a there's a number of artisans in it there's some slaves in it uh there's some freeborn persons who are evidently are not artisans... in some ways that group would probably look an awful lot like let's say the um the thessalonian group",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "w-kWyeMMOWo_0",
+    "text": "Mason traces the Greek etymology of \"evangelion\" (Paul's key theological term) to Greek religious language, specifically to the term for Hermes as Zeus's faithful messenger. This supports the book's argument that early Christian terminology has Greek rather than purely Jewish roots.",
+    "quote": "the root is found but not this form... the adjective is fairly common it's used of the god hermes uh he's because he's the faithful messenger so he's called angelos the faithful messenger of zeus... you can rely on hermes to deliver your message",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "zfVbBaSuKNo_0",
+    "text": "Zinner demonstrates that Stoic philosophical principles fundamentally transformed early Christian theology, particularly Paul's spiritualization of the law. Paul adopted a \"stoic understanding of law\" that elevated natural law over written law, appropriating Jewish scriptures to support this Greek philosophical framework—a reinterpretation that \"doesn't square with Jewish tradition.\" This shows how Greek philosophical thought was embedded in the reframing of foundational Christian concepts.",
+    "quote": "Paul has a particular stoic understanding of law the nomas right uh which doesn't square with with Jewish tradition...natural law is superior to the laws of Nations right this is a stoic Trope right and he appropriates various uh tanak passages in order to read this stoic understanding of law into the Tanakh",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "1iExveFIcpE_2",
+    "text": "Tabor documents how Paul transformed the original political understanding of Jesus as the Davidic Messiah (heir to the kingdom of Israel) into a theology of Divine Son of God, illustrating the theological shift away from political-royal titles.",
+    "quote": "Jesus is claimed to be the davidic Messiah is essentially marginalized in order to assert his status as the Divine Son of God in Heavenly Christ",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "APjOTirtllk_1",
+    "text": "Tabor identifies Paul as potentially thinking of himself as \"kind of a second Christ\" and describes him being told to \"sit at my right hand,\" extending the book's argument about Hellenistic royal exaltation language beyond Jesus to Paul.",
+    "quote": "did Paul think of himself as kind of a second Christ... I think he might have been told Paul come up here sit at my right hand you know sit with me and then told go tell your people this is where you and all of them will someday be just as Jesus overcame and was glorified and sits at the right hand of God",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "CilDiHv4gzk_3",
+    "text": "Walsh discusses mistranslation of Greek grammatical constructions in theological texts—shifting \"faithfulness of Jesus\" (objective genitive) to \"faith in Jesus\" (subjective)—demonstrating how theological assumptions override linguistic accuracy in interpreting Paul's meaning.",
+    "quote": "whenever Paul's writing he'll talk about Moses's faithfulness Abraham's faithfulness but for some reason the New Testament when it hits Jesus's faithfulness we translate it as faith in Jesus...that's a theological decision that decision yeah it's not in the Greek",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "W1ic2ZXnqVo_3",
+    "text": "Walsh documents how Greek philosophical terminology is systematically translated differently in New Testament contexts than in classical Greek texts, obscuring Paul's reliance on Greek philosophical frameworks. Example: the genitive construction with pistis (faith/faithfulness) in Paul is changed from objective genitive to subjective genitive when applied to Jesus.",
+    "quote": "whenever Paul's writing he'll talk about Moses's faithfulness Abraham's faithfulness but for some some reason the New Testament when it hits Jesus's faithfulness will translate it as faith in Jesus...that's a theological decision that decision...it's not in the Greek",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "ezCnRZoKO5I_0",
+    "text": "Fredriksen articulates Christ's Davidic Messiah status as requiring conflict with pagan gods at his return, framing resurrection and eschatology as assertions of divine authority within the Mediterranean polytheistic hierarchy—a political-theological claim central to the book's Greco-Christian framework.",
+    "quote": "Christ needs to be fighting something when he comes back. And Paul provides that. He says that Christ will fight the pagan gods.",
+    "source_chapter": 3
+  },
+  {
+    "finding_id": "1nFge-jKLWU_0",
+    "text": "The rabbi identifies Hebrews as written in exquisite Greek, likely composed by a Hellenized author (possibly from Alexandria) influenced by Plato and the empire, supporting the thesis that early Christian institutional theology developed within Greek intellectual contexts.",
+    "quote": "this is probably coming out it's it's just so hard to know it reminds me of philo like a greekified hellenized type of alexandrian maybe the person's half jewish on his mom's side or something and he knows a little bit about the tanakh but he loves plato he loves the empire he loves like that's what it feels like when you're reading hebrews",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "0Qe68mIeCHY_1",
+    "text": "The speaker identifies Luke-Acts as representing a trajectory toward political-theological compatibility, where \"Christians are nicely agreed... there's no trouble between Peter and Paul,\" presenting a unified vision that would appeal to imperial governance—evidence of how early Christian rhetoric aligned with structural parallels to Roman administration.",
+    "quote": "Luke Acts is the first step towards Constantine... Christians are nicely agreed. They don't argue. There's no trouble between Peter and Paul in Luke acts.",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "5WrZnOVYy7U_2",
+    "text": "Lillie describes how First Timothy structures Christian communities hierarchically \"exactly like the patriarchal roman household with men on top of women subordinated children subordinated enslaved folk subordinated,\" showing how Church Fathers consciously mirrored Roman imperial household structures. This supports the book's thesis about Hellenistic institutional patterns.",
+    "quote": "first timothy where um where you definitely have like a household of god and um and the christian community is set up exactly like the patriarchal roman household",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "5kI6tecz_yc_2",
+    "text": "Matthew documents a consistent pattern in Acts: whenever Christians are accused, Roman governors and officials repeatedly appear to validate Christians as law-abiding and innocent. This shows how Luke's text constructs early Christianity as seeking legitimacy and integration within Greco-Roman political institutions.",
+    "quote": "at every point in comes the Roman Governor um in comes the Roman Pro Council to say no these Christians have done nothing wrong right right so over and over there's this reassurance which is what Luke promised his reader reassurance",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "5kI6tecz_yc_3",
+    "text": "Matthew details how Acts systematically responds to specific Greco-Roman imperial accusations against Christians (atheism, being anti-social separatists, meeting in secret, worship of a crucified man). This shows Acts engaging directly with the institutional and ideological concerns of the Greco-Roman world, supporting the thesis that early Christianity must be understood through Greco-Roman rather than purely Judeo-Christian frameworks.",
+    "quote": "the critique of Christians from an outsider's view when Christians get to become more known is that they are separatists that they are anti-social um that they're atheists because they don't worship...the city Gods...Luke answers all of those questions um uh uh by by presenting Christians as um well in some ways you know he really flips the accusation",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "CsovC_zw2sw_1",
+    "text": "The same passage describing Peter as Jesus's \"vice regent on earth\" provides concrete evidence for the book's argument that early Christianity mirrored Hellenistic political institutions. The explicit language of vice-regency (a political-administrative term) demonstrates early institutional continuity with Greco-Roman administrative structures and succession protocols.",
+    "quote": "jesus kind of passes the honor and the authority on to his vice regent on earth before he ascends",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "NOIxiGcnZoo_1",
+    "text": "Pervo traces how early Christian institutional structures with bishops, presbyters, and deacons became foundational to proto-orthodox Christianity, demonstrating the adoption of Greek political organizational models.",
+    "quote": "the Pauline Heritage...provided the major underpinnings to what is called early Catholic Christianity this movement...supported strong Church government by Bishops presbyters and deacons",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "NTK1bX4YfJo_3",
+    "text": "Carrier outlines how early Christianity would necessarily adopt the institutional patterns of Greco-Roman mystery religions: \"baptism... worship of a mythical historicized savior figure... death and a resurrection... sacred meals... brotherhood... salvation\"—providing concrete evidence for understanding early Christian institutions through Greco-Roman religious association models.",
+    "quote": "What would a Jewish mystery religion look like to the educated privileged classes?... there'd be worship of a mythical historicized savior figure... a death and a resurrection... salvation... sharing of sacred meals... founding of some sort of brotherhood through baptism.",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Rspshd_c7P0_5",
+    "text": "Lawson identifies Paul's theology as the key mechanism by which the original Jewish political messianism was transformed into a Greco-Roman theological framework: \"Paul modified the Old Testament prophesied Hebrew world king the Messiah into a greco-roman High Saviour God the Christ,\" illustrating how Hellenized theology replaced political kingship narratives.",
+    "quote": "Paul modified the Old Testament prophesied Hebrew world king the Messiah into a greco-roman High Saviour God the Christ using the authority of his personal revelation to discard any obligations",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "URhU2qdculU_5",
+    "text": "Miller discusses Eucharist language (\"eat and drink his flesh and blood\") as cultic practice enabling ongoing connection with the deified/translated figure—a Greco-Roman cultic mechanism rather than Jewish covenant renewal.",
+    "quote": "I think a signal to the cultic practice of Eucharist... you want his presence eat and drink his flesh and his blood that's what I think that whole story is about",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "VWHV7xErzWE_1",
+    "text": "Miller describes Hellenistic cities like Corinth as organized around dense networks of cultic institutions, temples, and religious precincts functioning as a unified political-religious infrastructure—the institutional environment into which early Christianity would integrate as another Greco-Roman cultic organization rather than as a sectarian Jewish movement.",
+    "quote": "Corinth... is a place bustling a dense Metropolis full of cultic symbolisms in fact the entire architecture of the city is described as basically a almost like um a smorgasbord of different cultic opportunities or beliefs or ways to express piety in different contexts and different cultic forms and belief systems precincts temples sacred trees all sorts of things... the whole city is probably best described as as in those terms",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Zee2wqjXG84_0",
+    "text": "Dr. Miller demonstrates that the Greek word \"pistis\" (commonly translated as \"faith\" or \"belief\") inherently encompasses political allegiance and fidelity—particularly allegiance to authority figures like emperors and commanders. He shows that early Christian conversion involved willful assent to a philosophical/cultic worldview structured like Hellenistic political communities, and references Justin Martyr's approach of presenting Christianity as a superior Hellenistic philosophy. This linguistic evidence supports the book's argument that early Christian theology and practice should be understood through a Greco-Christian institutional framework.",
+    "quote": "if someone would have Pistons toward the emperor this kind of thing you know pissed us towards your commander um and this kind of thing and I think that that also is part of the lexical range of what's going on in the New Testament",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "hWh7O5CZuTg_1",
+    "text": "Tabor emphasizes Paul's vision of believers as \"joint heirs with the messiah\" exalted \"above every rule authority and power in the whole universe,\" illustrating how Paul envisioned Christian identity as fundamentally involving participation in cosmic political dominion shared with Christ.",
+    "quote": "that doesn't just mean like oh jesus likes me i guess i'm his friend that means you are going to get exalted above every rule authority and power in the whole universe with god in this new cosmic family",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "vXb3iKVVsB4_0",
+    "text": "Dr. Price and the host argue that the Eucharist (a central Christian sacrament) derives from Greco-Hellenistic mystery religions (Osiris, Dionysus, Demeter) rather than Jewish sources, and cite the Ignatian epistles referring to it as the \"medicine of immortality.\" This supports the book's broader thesis that early Christianity should be understood through Greco-Christian institutional and theological context rather than exclusively Jewish tradition.",
+    "quote": "the lord's supper has no possible connection with judaism... the natural connection is with the mystery religions where they where you had us especially osiris and dionysus and and demeter also uh where they're gods and a goddess of of grain and grapes and that their devotees would uh consume the body and blood under the forms of bread",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "ymMGWCgaotY_1",
+    "text": "Price documents the pastoral epistles' institutional ecclesiastical development with formal boards of \"deacons and bishops and stipended widows,\" indicating early Christian organization adopted Greek administrative structures and vocabulary matching the apostolic fathers.",
+    "quote": "the pastoral epistles presuppose a much later ecclesiastical stage of development it's their boards of of deacons and bishops and stipended widows... the vocabulary fits with luke acts and the apostolic fathers not with any epistle attributed to paul",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "Yvv7uw5uZjI_1",
+    "text": "Christianity's structural parallels to Hellenistic mystery cults—initiation into esoteric mysteries, distinction between public narratives and private teachings for believers, and savior figures with death-and-resurrection narratives—support the thesis that Hellenistic institutional frameworks are essential for understanding early Christian theology and practice.",
+    "quote": "there is a distinction made within the new testament documents between mature and immature believers this is the exact structure of a mystery cult mystery cults are identified as any hellenistic cult where individual salvation was gained through a ritualized initiation into a set of mysteries",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "S2e6u2gQUTM_4",
+    "text": "Tabor describes James's leadership of the Nazarene community as parallel to rabbinic authority structures, sitting on a throne (throneos) to pronounce binding decisions, demonstrating the early church's adoption of Hellenistic political-institutional leadership models.",
+    "quote": "james is like a rabbi of the nazarenes right so what does he do everybody talks for a while and then he gets up and says my decision is this and remember he sits on the throneos or the throne of of the nazarene community",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "r6hrIn5gxco_2",
+    "text": "Tabor describes the early movement's headquarters on Mount Zion as a house church with wealthy patronage supporting Jesus and the disciples, and James as institutional successor of Jesus, suggesting early Christian organizational structures paralleled existing Hellenistic institutional patterns.",
+    "quote": "Jesus eats the last supper at the courtesy or support of a wealthy patron... James gets up... and he says, 'I've heard everybody my decision is'... James is the successor of Jesus and leads the group... Mary's the matriarch.",
+    "source_chapter": 6
+  },
+  {
+    "finding_id": "DMmr5ixaXbA_1",
+    "text": "Stanley notes that Asclepius, the Greek healing god, received titles and veneration closely parallel to early Christian language about Jesus—\"divine Savior,\" \"loving Lord and Master,\" \"the one who gives life\"—suggesting the Greco-Roman religious idiom for divine titles.",
+    "quote": "he is they have hymns to him as the divine Savior the loving Lord and Master uh and um you know the the one who gives life and all these kinds of things",
+    "source_chapter": 6
+  }
+]

--- a/sources/coverage/ch6_findings_redistrib_r1.json
+++ b/sources/coverage/ch6_findings_redistrib_r1.json
@@ -1,0 +1,38 @@
+[
+  {
+    "finding_id": "lX-TvMDoDP4_3",
+    "text": "The speakers note that Roman administrative divisions (seven hills, Parthian satrapies) were universally recognizable to contemporary audiences through Greek and Roman literature—supporting the book's emphasis that Greco-Roman institutional context was self-evident to early Christian readers.",
+    "quote": "the reference to Seven Hills as Rome is so common at this time in the first period the first century anyone reading this in the first century Seven Hills Rome there's no question",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "1aYH2YNev3c_0",
+    "text": "The discussion of Seleucid royal iconography (anchor and fish symbols) being adopted in early Christian imagery demonstrates Hellenistic cultural penetration. Clement of Alexandria explicitly confirms that the anchor symbol Christians used originated from Seleucid sources, showing the adoption of Hellenistic royal emblems.",
+    "quote": "clement of alexandria even tells us that yes these are the seals the symbols the visual symbols we christians use... the anchor and fish we get from the cellucids even the christian clement of alexandria admits that the origin of the christian symbol of the anchor comes from this pagan seleucid source",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "lX-TvMDoDP4_0",
+    "text": "The transcript discusses how Revelation emerges from \"hellenized Judaism\" and references Sibylline oracles—Jewish pseudepigraphal texts using Greek apocalyptic forms. This supports the book's argument that Hellenistic institutional context was fundamental to understanding early Jewish-Christian texts, addressing the thin area of \"Pre-Hasmonean Hellenistic period\" influences.",
+    "quote": "it comes out of that hellenized Judaism time period where you have Jewish sybilis these pseudopigraphy texts that are very very strange and apocalyptic",
+    "source_chapter": 2
+  },
+  {
+    "finding_id": "au3cEE0w6OQ_0",
+    "text": "The vesica Pisces, a fundamental geometric form from Greek mathematics, is identified as core to earliest Christian symbolic tradition and iconography (the fish symbol). This indicates Greek mathematical and geometric frameworks were integral to Christian identity and symbolic expression from the earliest period.",
+    "quote": "some of the earliest Christian Christian symbolism was the fish and vesica Pisces literally translates to the vessel of the fish",
+    "source_chapter": 4
+  },
+  {
+    "finding_id": "O1cxMlDgTa8_4",
+    "text": "Soul Invictus operated as an organized imperial religious institution with structured feasts, maximum chariot races, and institutional hierarchy, demonstrating the Greco-Roman political-religious institutional framework that Christian communities operated within and later adopted. This supports the book's argument about Hellenistic institutional context.",
+    "quote": "So Solindictus has the maximum amount of soul of horse racing chariots. It's a major holiday... The birthday of Caesar Augustus only gets 24... That's a major holiday... It was a minor holiday, barely even a holiday. But [around 274 AD] they became a festival, a major festival, a feast to Soul Invictus.",
+    "source_chapter": 5
+  },
+  {
+    "finding_id": "O1cxMlDgTa8_5",
+    "text": "Church Fathers explicitly adopted and consecrated pagan institutional and physical structures, demonstrating the continuity of Hellenistic political-theological institutions. The transcript documents Pope Gregory's directive to \"reconsecrate sacred buildings, sacred temples... keep the pagan structure and just replace the icons,\" showing systematic institutional integration rather than replacement.",
+    "quote": "Christians seem to be a bit more like you talk about the Pope Gregory kind of like, hey, we're going to stamp our feast days... we're going to imitate what they have, but put Christ on it... reconsecrated sacred buildings, sacred uh temples, uh all of this stuff keeps getting recycled within Christian circles.",
+    "source_chapter": 5
+  }
+]


### PR DESCRIPTION
## Summary
- Add `--redistribute` command to `build_coverage.py` that collects `wrong_chapter` verdicts, parses target chapters, and creates batch files for re-evaluation
- Iterative convergence loop with max 3 rounds and ping-pong detection
- Round 1 output: 208 findings redistributed across 6 chapters (Ch4 receives 80, Ch3 receives 51, Ch5 receives 41)
- Update DD-0002 with redistribution loop documentation

## Test plan
- [x] `--redistribute --round 1` produces 6 batch files with 208 total findings
- [x] All findings have non-empty text and quote content
- [x] No finding appears in its own source chapter's batch
- [x] `--redistribute --round 2` reports convergence (no verdict files yet)
- [x] `--redistribute --round 4` correctly errors at max round cap
- [ ] Evaluation agents process redistrib batch files and write verdict files
- [ ] `--redistribute --round 2` after evaluation confirms convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)