### PR TITLE
feat: ch3 — Septuagint evidence for pre-Christian christos

### DIFF
--- a/chapter3.tex
+++ b/chapter3.tex
@@ -447,6 +447,14 @@ Messiah is the authentic Judean royal title applied to Jesus, naming the anointe
 Messiah refers to an actual political ruler, not a mythical or purely future savior.
 The common claim that Messiah names only an end-times figure is false and contradicts Judean political practice.
 \emph{Christos} (Χριστός) was an existing Greek word meaning ``anointed'' and did not originate as a Christian invention.
+In 1 Samuel 24:6 (LXX 1 Kingdoms 24:7), Saul is called ``the Lord's \emph{christos},'' and David refuses to strike him on that basis.
+In 2 Samuel 19:21 (LXX 2 Kingdoms 19:22), David himself is named ``the Lord's \emph{christos}'' as the reigning king.
+Psalm 2:2 speaks of rulers gathering ``against the Lord and against his \emph{christos},'' using the term as a royal title in a political setting.
+Leviticus 4:3 defines the high priest as ὁ ἱερεὺς ὁ χριστός, the anointed priest holding consecrated office.
+The term therefore applies across offices, marking both kingship and priesthood as anointed authority.
+Isaiah 45:1 extends this further by calling Cyrus the Persian emperor ``the Lord's \emph{christos}'' (Κύρῳ τῷ χριστῷ μου).
+This applies the title to a foreign imperial ruler chosen for a political role, not a Jewish king.
+\emph{Christos} in Greek already denotes a ruler or office-holder set apart by divine sanction across national boundaries.
 Anointing kings was common across the ancient world, but Messiah names the specifically Judean form of that practice.
 The Hasmoneans ruled Judea as anointed priest-kings, combining high priesthood, kingship, military command, and Temple authority under figures such as Simon, John Hyrcanus, and Alexander Jannaeus.
 Their rule ended only one generation before Jesus, with Herod taking power in 37~BC and Jesus born around 4~BC.


### PR DESCRIPTION
## Summary
- 8 sentences after "did not originate as a Christian invention" (line 449)
- Saul (1 Sam 24:6), David (2 Sam 19:21), Psalm 2:2 — royal title
- Leviticus 4:3 — priestly office
- Isaiah 45:1 — Cyrus the Persian called christos, extending beyond Israel
- Anchors the existing claim with specific LXX citations

## Test plan
- [ ] LaTeX compiles
- [ ] Text flows between line 449 and "Anointing kings was common"

🤖 Generated with [Claude Code](https://claude.com/claude-code)