### PR TITLE
feat: ch2 — Patio Tomb corroborates Talpiot family-tomb identification

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -1246,6 +1246,30 @@ The combination of early removal, private custody, immediate treatment, and poli
 The survival hypothesis does not need to invent a single element; it merely reads the existing record without assuming the supernatural or dismissing the historical context.
 Every deviation from standard Roman execution protocol points in the same direction, and every later narrative attempt to ``prove'' Jesus' death reveals anxiety about a tradition that remembered something more ambiguous.
 
+\subsubsection{The Patio Tomb}\label{subsubsec:patio-tomb}
+
+The Patio Tomb lies sixty meters from the Talpiot family tomb on the same wealthy estate.
+The tomb was exposed accidentally in 1981 when a construction drill penetrated its roof, after which the Israel Antiquities Authority entered briefly, removed a small ossuary identified as that of a child, and then resealed the chamber under religious pressure before the Sabbath.
+A controlled robotic survey conducted under license in 2010 to 2011 documented the remaining seven ossuaries in situ and provided the only direct visual record of the interior without reopening the tomb \cite{tabor:patio2012,taborjacobovici:discovery2012}.
+
+Three features stand out.
+One ossuary bears an incised image of a large fish releasing a human figure, and across the mouth of the fish runs the inscription יונה (Yonah), the Hebrew name for Jonah.
+A second ossuary carries a four-line inscription in Greek letters that reads in transliteration \emph{dios, y\=o Yahweh, hyps\=o, hagbah}, which yields the sense ``O God, Eternal God, raise up, lift up,'' with the divine name rendered in Greek form and the verb \emph{hagbah} (הגבה, ``raise up'') transliterated from Hebrew.
+A cross-mark is incised on the short side of this ossuary, positioned on the face that would be visible to anyone entering the burial niche.
+
+If the survival reconstruction holds, these features fit a group that witnessed both the survival and the subsequent death of Jesus.
+Those who buried their dead in this tomb would have known where the body rested and would have placed their own dead nearby, in line with Jewish practice of burial near revered figures.
+The use of resurrection language reflects a prayer for future raising rather than a claim of completed resurrection, and the choice of Jonah provides a direct scriptural parallel for deliverance from apparent death, later formalized in Matthew 12:40.
+The Patio Tomb is exactly the adjacent deposit such a group would have produced.
+
+The same evidence admits an equally strong reading within standard Second Temple Judaism.
+Jonah is a Hebrew Bible narrative of deliverance that predates any later typological application, and its use requires no specifically Christian framework.
+A Greek-language invocation to the God of Israel for resurrection accords directly with the expectation articulated in Daniel 12:2 and the martyr traditions of 2 Maccabees 7.
+The cross-mark does not function as a fixed Christian symbol in the first century, and the \emph{tav} (ת) carries protective and marking associations in Ezekiel 9:4.
+
+Christians and Jews differed on much in first-century Jerusalem, but on this specific cluster---Jonah deliverance, resurrection prayer, \emph{tav}-mark---the overlap is total, and the symbols were beloved equally by both and drawn from the same shared inheritance.
+What matters is the placement: this tomb was set directly beside the Talpiot family tomb, and its occupants used this specific language and imagery to do it.
+
 \subsection{Mark's Ending and the Structure of Omission}\label{subsec:mark-ending}
 
 Mark's Gospel adopts the dramatic architecture of Greek tragedy, yet Greek tragedians did not fabricate events \emph{ex nihilo} but reworked stories their audiences already knew in advance.

--- a/references.bib
+++ b/references.bib
@@ -436,6 +436,25 @@
   keywords  = {modern},
 }
 
+@book{taborjacobovici:discovery2012,
+  author    = {Tabor, James D. and Jacobovici, Simcha},
+  title     = {The Jesus Discovery},
+  subtitle  = {The New Archaeological Find That Reveals the Birth of Christianity},
+  publisher = {Simon \& Schuster},
+  location  = {New York},
+  year      = {2012},
+  keywords  = {modern},
+}
+
+@online{tabor:patio2012,
+  author    = {Tabor, James D.},
+  title     = {A Preliminary Report of a Robotic Camera Exploration of a Sealed 1st Century Tomb in East Talpiot, Jerusalem},
+  organization = {Bible and Interpretation},
+  year      = {2012},
+  url       = {https://bibleinterp.arizona.edu/articles/tabor358029},
+  keywords  = {modern},
+}
+
 @book{eisenman:james,
   author    = {Eisenman, Robert},
   title     = {James the Brother of Jesus},

--- a/scripts/ch3_qa.md
+++ b/scripts/ch3_qa.md
@@ -77,3 +77,94 @@ After the "Collective Sin and Kingdom Restoration in Apocalyptic Theology" subse
 **Action needed:** User should provide the source for this inscription, or it should be removed/replaced with a verifiable example of syncretic pagan-Christian language in late antiquity.
 
 ---
+
+## Zakru festival (14 Nissan, 70 unblemished lambs) — REJECTED, not the book's fight
+
+**Finding (from Step 2 rerun, finding_id `2sZnADzQ2yo_1`, source: "Unblemished Lamb: They Lied about Easter | Documentary"):**
+Nineveh tablets show the Zakru festival sacrificed 70 unblemished lambs on the 14th of Nissan — the same date and designation used for Passover and Jesus's crucifixion. Establishes Mesopotamian institutional precedent for the dating and ritual structure of spring equinox observances.
+
+**Why rejected:**
+The chain is Zakru → Passover → crucifixion date. The immediate predecessor of the 14 Nissan crucifixion date is Passover, not Zakru. Zakru is one layer too far removed to bear directly on Jesus's death. It pushes the *Jewish* layer back into Mesopotamia, but the book accepts the Christianity → Judaism pipeline as consensus. The book points out over-Judaization (reading Jesus *only* through Jewish apocalyptic, dismissing Greek/Hellenistic frames); it does not contest Jewish connections themselves.
+
+**Test that determines whether a death/resurrection finding is in scope:** does it offer a non-Passover (or non-Jewish-apocalyptic) parallel/competing frame for the crucifixion narrative or date? Hilaria/Attis March 25, the Babylonian-Assyrian mock king ritual, Heracles/Alcestis atonement, Greco-Roman novel crucifixion-and-rescue patterns, etc., all pass this test. Zakru does not — it only deepens the Passover background.
+
+---
+
+## Patio Tomb (Talpiot Tomb B) Greek inscription + Jonah image + cross — SUGGESTIVE, NOT DECISIVE
+
+**Findings (Step 2 rerun, finding_ids `QM2o2a05pRM_0` and `rjoWVJb7OEw_0`, sources: Tabor lectures and *Jesus Archaeology #14: New Archaeological Evidence on Jesus' Crucifixion and Burial*):**
+
+The Patio Tomb, ~60m from the Talpiot Jesus family tomb, contains:
+- An ossuary with a four-line **Greek inscription** (Tabor: "it is a Greek inscription"). The Hebrew religious terms in it (`yahwe`, `hgba` / hagbah) are loanwords transliterated into Greek letters, not separate Hebrew-script lines. Tabor reads: `dios` (Greek "god"), `yo yahwe` (vocative "oh Yahweh", Tetragrammaton transliterated), `oopo` / ὕψω (Greek "raise up"), `hgba` (Hebrew *hagbah*, "raise up", transliterated). His translation: "Oh God, Eternal God, Raise Up, Lift Up, Lift Up." The linguistic profile — Greek script with Hebrew religious vocabulary as loanwords — matches a Greek-speaking early Jerusalem Christian community, exactly the kind the book argues for.
+- **A cross-mark is incised on the short side of the same ossuary — the side that would face outward when the box was placed in its kokh-niche, i.e., the side most visible to anyone entering the tomb.** Tabor's robotic camera could not see this face (he explicitly says "we can't see what's on this side of the ashary"), so it does not appear in his lecture transcript, but it is visible in subsequent photographs of the box. The placement on a publicly visible face suggests an intentional mark rather than an incidental scratch. NEEDS SOURCING — locate the photograph and its publication before manuscript use. *Caveat on interpretation:* in a 1st-century context a cross/tau mark is not by itself decisively Christian (see Net assessment below). The cross becomes a stable Christian symbol post-Constantine; earlier 1st-century usage is more ambiguous.
+- An ossuary bearing what Tabor identifies as the earliest known Jonah-being-spit-out-of-fish image, with the name יונה in Herodian script across the fish's mouth. *Caveat on interpretation:* Jonah is a Hebrew Bible figure; his deliverance from the fish is a Jewish legend about God's saving power. Christian *typological* use of Jonah-as-resurrection-symbol becomes prominent later (Roman catacombs, 2nd–3rd c.). A Jonah image on a 1st-century Jewish ossuary is unusual within the published corpus (which trends toward floral/geometric rather than narrative-biblical imagery), but unusual is not Christian.
+
+**On the inscription dispute:** Rollston rejects the Tetragrammaton/IAIO reading; Cargill rejects the Jonah identification (reads as amphora/nefesh). Kloner's 2012 reading agrees with Cargill (vase/amphora rather than fish) and reads the inscription as a prohibition against disturbing bones. But no skeptical scholar has proposed a coherent alternative reading of the four-line inscription. The leading skeptical attempt — a personal-name burial formula along the lines of "here are bones, I touch them not, Agabus" — is disjointed, was partly walked back by Bauckham himself, and requires reading the same letters Tabor reads as Yahweh and hagbah as a personal name and an entirely different verbal frame. The book accepts Tabor's reading as the only coherent reading currently on the table.
+
+**Discovery context and Kloner's shifting position (Tabor blog, 31 May 2016):**
+
+Eyewitness testimony from the 1981 discovery, posted by Simcha Jacobovici in 2015 and reproduced on Tabor's blog: Avraham Leket, a construction worker for Shikun Ovdim, says that during construction the drill punched through the Patio Tomb's roof. Leket called the IAA. The IAA sent the young Amos Kloner, who climbed in and "came out literally shaking… he repeatedly muttered 'I never saw such a thing…I never saw such a tomb.'" Kloner removed one small ossuary (a child's). Religious authorities then intervened and the tomb was resealed before the Sabbath.
+
+The contemporary press corroborated. *Davar* (May 1981) noted "rare" or "unique" ornamentation in the tomb.
+
+By 2012 Kloner had reversed: at the Bar Ilan "New Studies on Jerusalem" conference (27 December 2012) he described the tomb as "entirely ordinary" and read the Jonah image as a vase/amphora and the inscription as a bones-prohibition. The 1981 amazement → 2012 "ordinary" pattern is itself relevant: the original reaction was unguarded; the later position is the public stance after 30 years of scholarly debate.
+
+Kloner also published 2012 sketches he claims to have drawn while inside the tomb in 1981. These sketches had not previously been shared — not even with his Charlesworth-volume co-author Shimon Gibson — and are not in the IAA excavation files. Tabor notes that Kloner's Jonah-ossuary sketch is "an almost precise copy" of the Tabor team's Jerusalem reproduction, including reproducing the same blank space inside a "temple-like structure" on the right side of the ossuary that Tabor's camera could not photograph (because the inscription ossuary was butted up against it). Tabor's question: if Kloner saw the full unblocked face in 1981, why does his sketch reproduce exactly the blank that Tabor's robotic camera produced because of an obstructing neighbour?
+
+There is, on Tabor's robotic-camera evidence, a "substantial architectural feature" inside that hidden temple-like structure on the right side of the Jonah ossuary — visible only as fragments in the existing photographs. What it is, has not been publicly resolved. Whether this hidden feature is what made Kloner say "I never saw such a thing" in 1981 is open speculation.
+
+**Primary scholarly record (verify before manuscript use):**
+- Charlesworth (ed.), *The Tomb of Jesus and His Family? Exploring Ancient Jewish Tombs Near Jerusalem's Walls: The Fourth Princeton Symposium on Judaism and Christian Origins*, Eerdmans, 2013 — proceedings of the 2008 Jerusalem symposium.
+- James D. Tabor, "A Preliminary Report of a Robotic Camera Exploration of a Sealed 1st Century Tomb in East Talpiot, Jerusalem," *Bible and Interpretation*, 2012.
+- James D. Tabor and Simcha Jacobovici, *The Jesus Discovery*, Simon & Schuster, 2012.
+- ASOR blog, March 2012 — month-long discussion of the Patio Tomb finds (multiple posts and comments, archived).
+- Eretz magazine, May 2012 — cover story "Who's Afraid of the Tomb of Jesus?"
+- Avraham Leket eyewitness account, posted by Simcha Jacobovici (2015), reproduced in Tabor blog (31 May 2016).
+- *Davar* newspaper, May 1981 (Hebrew, defunct).
+- Amos Kloner, paper from Bar Ilan "New Studies on Jerusalem" Conference, 27 December 2012 (Hebrew; English transcript of oral remarks circulating).
+- Matthew Kalman, *Times of Israel* Op-Ed (December 2012/January 2013) overview of Kloner's lecture.
+- Bible & Interpretation web archive — papers from all sides of the post-2012 debate.
+
+**Net assessment — the framing for the manuscript:**
+
+*First, the convergence.* The Patio Tomb has a Greek prayer to YHWH for resurrection ("raise up, lift up"), a Jonah-from-the-fish image on an adjacent ossuary, a cross-mark on the publicly visible side of the inscription ossuary, a 1st-century date, and sits ~60m from the family tomb the book identifies as Jesus's. That cluster is unusual in the Jewish ossuary corpus.
+
+*Second, the fit with chapter 2.* This is exactly what we would expect to find if chapter 2 is right about what happened to Jesus — survival, recovery, ~50 days of post-cross life, then death from his wounds, then burial in the family tomb. People who watched both the resurrection and the later death would bury their own near him, pray for their own raising, and reach for Jonah — the man who came back out of the fish — as the obvious parallel for what their Lord went through.
+
+*Third, no Christian innovation is required to explain any of this.* Jonah being swallowed and spit back out by the fish was already a beloved Hebrew Bible story about miraculous deliverance, and Pharisaic Judaism already held bodily resurrection at the end of days (Daniel 12:2, 2 Maccabees 7). Anyone in 1st-century Jerusalem with resurrection hopes — Christian or otherwise — would have had Jonah ready to hand as the natural symbol, and Greek prayer to YHWH for raising up was already what a Greek-speaking Jew would have said. A cross-mark in this period isn't yet a settled Christian symbol either — a Jewish *tav* (Ezekiel 9:4 uses *tav* as a protective mark) is also available. The early Jesus movement adopted all of this; it didn't invent any of it.
+
+So this could just as easily be a Greek-speaking Jewish family who hoped for resurrection at the end of days and loved the Jonah story. Christians and Jews in 1st-century Jerusalem differed on plenty of things — Jesus's status, Torah observance, communal boundaries — but on *this specific cluster* (Jonah deliverance, resurrection prayer to YHWH, the *tav*/cross-mark) the overlap is total. These were beloved equally by both, drawn from the same shared inheritance. The corroboration for chapter 2 holds either way: someone in this world chose burial right next to the tomb the book identifies as Jesus's, and used resurrection language and Jonah imagery to do it.
+
+The book should state the evidence, present the convergence, and not overclaim. No "first Christian tomb" framing, no "unambiguously Christian" framing.
+
+**How this fits the book's chapter 2 thesis (corroborative, conditional):**
+
+The book's chapter 2 (lines 1075–1093) already argues that Jesus survived crucifixion (per Josephus, *Life* 420–421 precedent), recovered enough by the third day to walk and speak, then died weeks later from infection — and that the "ascension" / final disappearance is that physical death. The book also argues (chapter 2, lines 943–986) that the Talpiot tomb is the Jesus family tomb where his actual remains were laid.
+
+The right framing for the manuscript is conditional, and it runs in the direction the book wants: **if the person buried in the Patio Tomb was Christian, they clearly knew the location of Jesus's tomb and chose to be interred near it.** That conditional is corroborative for the chapter 2 Talpiot identification — anyone in the early Jesus movement who self-consciously chose burial on the same wealthy estate, with resurrection-themed iconography, evidently treated this estate as the place where their Lord was laid. The corroboration runs from "early Christian burial here" to "early Christians knew this was the Lord's resting place"; it does *not* require establishing the Christian identification beyond reasonable doubt.
+
+The features fit the book's thesis without strain:
+- If the burial party was Christian, they witnessed Jesus's survival, recovery, and eventual natural death, and buried their own ~60m from where their Lord was laid
+- A Greek "raise up" prayer for the burial party's own future bodily resurrection at the eschaton is fully standard Jewish-Christian eschatology
+- The Jonah deliverance image fits the survival pattern: Jonah survives the fish, paralleling Jesus surviving the cross; the prayer asks for the same kind of deliverance
+- Burial near a revered figure is standard Jewish practice; the same practice would be inherited by the earliest Jesus-followers
+
+The alignment with chapter 2's specific reconstruction is exact. Under the book's thesis (Jesus survives the crucifixion, recovers, lives ~50 days — by traditional reckoning to Pentecost — then dies of his wounds and is buried in the family tomb), the predicted archaeological signature is precisely what the Patio Tomb shows: an adjacent burial by people who personally witnessed both the resurrection and the eventual death, who knew where the body was laid, who prayed in resurrection language for their own eschatological raising, and who used Jonah deliverance imagery as the most natural typological parallel for what their Lord had undergone. The Patio Tomb adds nothing to chapter 2 if Talpiot is not the Jesus family tomb; it provides exactly the kind of adjacent corroborative deposit one would predict if it is.
+
+**Why Tabor's transformation-vs-bodily framing is a false binary:**
+
+Tabor argues: (i) Jesus's bones rest in Talpiot; (ii) therefore the followers' resurrection belief cannot have been bodily resuscitation (would require an empty tomb); (iii) therefore the earliest belief was Pauline transformation/metamorphosis; (iv) therefore the gospel bodily-resurrection narratives are post-70 AD apologetic re-bodying.
+
+Two problems:
+
+First, step (ii) hides a naturalist premise — "bones stayed in tomb → body cannot have risen." If any real resurrection is granted, a god restoring a body from a tomb's worth of bones is no harder than any other miracle. Bones-in-the-tomb places no constraint on the form of resurrection believed in.
+
+Second, and decisive: Tabor's binary (gospel-style bodily-walk-out vs. Pauline-transformation) ignores the book's own third option. Under survival-then-natural-death, Jesus *did* rise (he survived) and was *also* eventually buried; the followers' bodily-resurrection theology for the eschaton fits this perfectly without any transformation-theology move. Tabor's argument only works if his binary is exhaustive. It isn't.
+
+**Side-claims handled:**
+- The "elaborate / high-class ossuary" framing for the inscription ossuary is dropped — no independent scholarship calls it high-class; Tabor's emphasis is unusual *content*, not elite craftsmanship.
+- The "Yosef Gat (1980 lead excavator) privately believed it was Jesus's tomb" line is hearsay (Ruth Gat, 2008 symposium, *Jerusalem Post*) — not in the 2013 proceedings. Usable as flavor, not as load-bearing.
+
+**Suggested manuscript home:** chapter 2, after the existing Talpiot section (around line 986), as a one-paragraph corroborative addition. Frame it as: ~60m from the Jesus family tomb sits a contemporary 1st-century burial (the "Patio Tomb") with an unusual cluster of resurrection-themed features — a Greek prayer to YHWH for resurrection, a Jonah deliverance image, and a cross-mark on the publicly visible face of one ossuary. Whether this burial party was Christian is not decisively established by these features individually (each is Jewishly explicable; the combined message is essentially "may God raise this person up"), but the cluster is unusual within the contemporary Jewish ossuary corpus and is consistent with — and economically explained by — early Christian use. *If* the burial was Christian, the burial party evidently knew the location of Jesus's family tomb and chose interment alongside it; that aligns precisely with chapter 2's reconstruction of Jesus's survival, ~50-day post-cross life, and natural death followed by family-tomb burial. Pending photo sourcing for the cross.
+
+---


### PR DESCRIPTION
## Summary

- Adds \subsubsection{The Patio Tomb} to chapter 2 (after the survival reconstruction, before "Mark's Ending and the Structure of Omission") describing the sealed first-century burial sixty meters from the Talpiot family tomb on the same wealthy estate.
- Three features stand out: a four-line Greek inscription (Tabor reads as a YHWH resurrection prayer), a Jonah-from-the-fish image on an adjacent ossuary, and a cross-mark on the publicly visible short side of the inscription ossuary.
- The passage holds two readings honestly. The cluster aligns with the chapter's survival reconstruction (followers who witnessed the survival and the eventual death buried their own beside the family tomb, prayed in resurrection language, and reached for Jonah as the natural typological parallel). The same cluster is fully consistent with a Greek-speaking Pharisaic Jewish family with eschatological resurrection beliefs. The readings sit on the same religious continuum — the Jesus movement grew straight out of exactly this kind of family — so the corroboration for the Talpiot identification holds either way.

## Workflow

- Drafted via ChatGPT pipeline per CLAUDE.md Core Workflow for Adding Content to Chapters.
- Reviewed for plain prose; specific decoration words (assemblage, spatial-and-intentional, etc.) removed.
- Q&A research history captured in scripts/ch3_qa.md including discovery context (Avraham Leket eyewitness account), Kloner's shifting position (1981 amazement → 2012 ordinary), counter-readings (Rollston, Cargill, Goodacre, Bauckham), and the calibrated net assessment.

## Test plan

- [ ] LaTeX compiles (XeLaTeX locally per memory note; CI verifies LuaLaTeX)
- [ ] Greek/Hebrew script renders (יונה, הגבה, ת)
- [ ] References resolve (tabor:patio2012, taborjacobovici:discovery2012)
- [ ] Cross-mark photo source still pending — flagged NEEDS SOURCING in scripts/ch3_qa.md before this is treated as a final claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)