### PR TITLE
feat: ch2 — Adonis at Daphne as Mark's local cultic pattern

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -1286,6 +1286,36 @@ Romulus, Heracles, Aristeas, and Apollonius are all subsumed by the logic of apo
 Mark refuses that entire symbolic grammar, presenting neither transformation nor ascension nor divine manifestation, and the narrative stops before the interpretive payoff expected in mythic literature.
 The absence of apotheosis where apotheosis should be is itself evidence that Mark is not constructing a mythic pattern but preserving a tradition that resisted such embellishment.
 
+Mark refuses Greek apotheosis but is not without a pattern, and the Phoenician dying and returning god type stood at his doorstep in Antioch.
+Daphne is the famous suburb of Antioch on the Orontes, and the Adonis cult had its sanctuary there.
+Adonis takes his name from Phoenician \emph{adon} (אדון), ``lord.''
+The Adonia rite is described in detail by Lucian of Samosata, a Syrian writer of the 2nd century AD, in \emph{De Dea Syria} 6 to 7.
+The text records the cult as practiced at Byblos on the Phoenician coast.
+Women anoint the dead lord with oils.
+They mourn him.
+On the second or third day they announce he is alive.
+No body is taken up.
+No ascent is narrated.
+Origen, the 3rd-century Christian biblical commentator, identifies Tammuz with Adonis as the same figure in his \emph{Selecta in Ezechielem}.
+
+Mark 16:1 records that the women bring spices to anoint the body, using \emph{aleipho} (αλειφω).
+Mark 16:5 to 6 records that they find the tomb open and hear that Jesus has been raised.
+Mark 16:8 records that the women flee in fear and tell no one.
+The Adonia follows the same sequence.
+Women come with oils to anoint the dead lord.
+The body is absent in the \emph{aphanismos} (αφανισμος, ``disappearance'') phase.
+The announcement of life belongs to the \emph{heuresis} (ευρεσις, ``finding'') phase.
+The rite ends without public display.
+
+The names converge on a shared language of lord and anointing.
+\emph{Adon} (אדון) names the lord in Phoenician and Hebrew.
+\emph{Kyrios} (κυριος) names the lord in Greek usage across the New Testament.
+\emph{Christos} (χριστος) names the anointed one.
+\emph{Baal} names the lord in Canaanite usage.
+Mark's scene of women anointing the lord at the tomb stands inside this language.
+Phoenician and Anatolian dying and returning gods, including Tammuz and Adonis with Attis as a cousin, differ from Greek Olympian apotheosis in that the body is not taken up and the focus rests on disappearance and announcement.
+Mark wrote in Antioch and used the pattern present at Daphne, and his ending therefore closes in silence rather than ascent, which leads directly into the abrasive structure that follows.
+
 Mark's ending is structurally abrasive rather than theatrically complete, denying its readers triumph, recognition, closure, or even stable witness testimony.
 The women flee in fear, the message is not delivered, and the final scene collapses into silence, which is the opposite of the polished finales that literary invention typically requires.
 A fabricated account would resolve tension through revelation or catharsis, while Mark punctures the narrative at its most sensitive point and entrusts the reader with an unresolved fragment.


### PR DESCRIPTION
## Summary

Adds three paragraphs to chapter 2 between the existing Mark-refuses-Greek-apotheosis paragraph and the Mark-ending-is-abrasive paragraph. With the chapter's earlier Antiochene placement of Mark in mind, the passage anchors that placement to local cultic detail: the Adonis cult at Daphne (the famous Antiochene suburb on the Orontes) provides the dying-and-rising god pattern Mark's empty-tomb scene tracks beat for beat.

The match: women anoint the dead lord with oils (Mark 16:1; the Adonia rite per Lucian, De Dea Syria 6-7), the body is absent in the aphanismos phase (Mark 16:5-6), the announcement of life belongs to the heuresis phase, and the rite ends without public display (Mark 16:8). The lord-anointing semantic family — adon (Phoenician), kyrios (Greek), christos (anointed), baal (Canaanite) — converges on the same vocabulary.

## Workflow

- ChatGPT drafted the passage per CLAUDE.md "Core Workflow for Adding Content to Chapters."
- Multiple revision passes removed decoration ("cultic grammar", "rooted in the Levantine cycle") and boast framing ("This book adds a narrower observation"). Final draft is plain-prose register, short declarative sentences, no modern-scholar name-drops.
- Citation-context patches applied for Lucian (identified as 2nd-c. AD Syrian writer, Byblos location given) and Origen (identified as 3rd-c. Christian biblical commentator).

## Test plan

- [ ] LaTeX compiles (XeLaTeX local; LuaLaTeX in CI)
- [ ] Greek/Hebrew script renders (αλειφω, αφανισμος, ευρεσις, κυριος, χριστος; אדון)
- [ ] Passage flows from preceding paragraph and into "Mark's ending is structurally abrasive"

🤖 Generated with [Claude Code](https://claude.com/claude-code)