### PR TITLE
fix: ch2 — anchor Adonia rite in pre-Christian sources (hotfix #108)

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -1291,6 +1291,10 @@ Daphne is the famous suburb of Antioch on the Orontes, and the Adonis cult had i
 Adonis takes his name from Phoenician \emph{adon} (אדון), ``lord.''
 The Adonia rite is described in detail by Lucian of Samosata, a Syrian writer of the 2nd century AD, in \emph{De Dea Syria} 6 to 7.
 The text records the cult as practiced at Byblos on the Phoenician coast.
+The rite predates Christianity by centuries, and Lucian preserves a later form of an older practice.
+Theocritus, \emph{Idyll} 15, describes the Adonia at Ptolemaic Alexandria in the 3rd century BC with the bier display, anointing oils, and women's lament.
+Sappho fr.\ 140 already gives the lament for the dying Adonis around 600 BC: ``Cytherea, beautiful Adonis is dying; what shall we do; beat your breasts, women, and rend your tunics.''
+The wider Tammuz tradition is attested in cuneiform sources from the 3rd millennium BC, placing the pattern deep in the ancient Near Eastern record.
 Women anoint the dead lord with oils.
 They mourn him.
 On the second or third day they announce he is alive.


### PR DESCRIPTION
## Summary

PR #108 cited Lucian's De Dea Syria (2nd c. AD) as the primary source for the Adonia rite, exposing the passage to the question: "how do we know the Adonia predates Christianity?"

This adds four sentences anchoring the rite in pre-Christian sources, slotted between the existing Lucian/Byblos lines and the ritual sequence description:

- Theocritus, Idyll 15 (3rd c. BC) — Adonia at Ptolemaic Alexandria with bier display, anointing oils, women's lament
- Sappho fr. 140 (~600 BC) — earliest extant Greek dirge for the dying Adonis, with the famous quote
- Tammuz cult cuneiform attestations (3rd millennium BC) — Mesopotamian cousin pattern

## Workflow

ChatGPT-drafted addition, curly quotes patched to LaTeX style on insertion. No modern-scholar names in text. Inline ancient citations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)