### PR TITLE
feat: ch2 — Mark's mockery scene tracks the Mesopotamian substitute-king ritual

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -1320,6 +1320,32 @@ Mark's scene of women anointing the lord at the tomb stands inside this language
 Phoenician and Anatolian dying and returning gods, including Tammuz and Adonis with Attis as a cousin, differ from Greek Olympian apotheosis in that the body is not taken up and the focus rests on disappearance and announcement.
 Mark wrote in Antioch and used the pattern present at Daphne, and his ending therefore closes in silence rather than ascent, which leads directly into the abrasive structure that follows.
 
+Mark's trial and mockery scene preserves a second Antiochene pattern --- the Mesopotamian substitute-king ritual.
+Mark 15:15 states that Pilate orders Jesus scourged.
+Mark 15:17 states that the soldiers clothe him in \emph{porphyran} (πορφυραν), purple.
+They place a crown of thorns, \emph{stephanon ex akanth\=on} (στεφανον εξ ακανθων), on his head.
+Mark 15:18 records the acclamation, ``Hail, King of the Jews.''
+Mark 15:19 records that they strike his head with a reed and kneel before him.
+Mark 15:20 records that they lead him out to crucifixion.
+
+This sequence matches the substitute-king ritual.
+A condemned man is dressed in royal robes and given the signs of kingship.
+He is acclaimed as king for a brief interval.
+He is struck and mocked.
+He is then executed in place of the king.
+Berossus records the Sacaea in Greek, \emph{Babyloniaca}, preserved in Athenaeus, \emph{Deipnosophistae} 14.639C.
+Dio Chrysostom describes the same pattern, \emph{Or.}\ 4.66 to 69.
+The elements align in order: robe, crown, acclamation, striking, execution.
+
+Mark preserves the full sequence.
+Matthew repeats the same elements in Matthew 27:27 to 31.
+Luke reduces the scene to a robe and mockery in Luke 23:11.
+John reorders the elements and presents Jesus to the crowd in John 19:1 to 5.
+That Mark holds the full Sacaea sequence --- and that Matthew copies it from him while Luke compresses and John reorders --- is evidence for an Antiochene author.
+The ritual was preserved in Greek by Berossus, Athenaeus, and Dio Chrysostom.
+The Greek-language records that transmitted it concentrated in the Seleucid Greek capital.
+Mark drew on this inheritance at Antioch, alongside the Adonis pattern at Daphne.
+
 Mark's ending is structurally abrasive rather than theatrically complete, denying its readers triumph, recognition, closure, or even stable witness testimony.
 The women flee in fear, the message is not delivered, and the final scene collapses into silence, which is the opposite of the polished finales that literary invention typically requires.
 A fabricated account would resolve tension through revelation or catharsis, while Mark punctures the narrative at its most sensitive point and entrusts the reader with an unresolved fragment.


### PR DESCRIPTION
## Summary

Extension of PR #108 (Adonis-at-Daphne Mark-Antioch passage). Adds three paragraphs to chapter 2 demonstrating that Mark 15:15–20 contains five specific ritual elements — purple robe, crown of thorns, mock acclamation, mock obeisance, scourging then execution — that match the Babylonian Sacaea / Assyrian substitute-king ritual sequence preserved in Greek by Berossus (Babyloniaca, in Athenaeus 14.639C) and Dio Chrysostom (Or. 4.66–69).

Mark holds the full sequence. Matthew copies; Luke compresses; John reorders. That Mark holds the complete form is concrete evidence for an Antiochene author — the Greek-language records transmitting this material concentrated in the Seleucid Greek capital where Mark wrote.

This is the second local-cultic-pattern parallel for Mark in the chapter, alongside the Adonis Aphanismos/Heuresis at Daphne (PR #108).

## Workflow

ChatGPT-drafted with revisions for plain-prose register and sharpened foregrounding of the Mark-Antioch evidence claim. No modern-scholar names in text. Inline ancient citations (Berossus, Athenaeus, Dio Chrysostom; Mark 15:15–20; Matthew 27:27–31; Luke 23:11; John 19:1–5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)