### PR TITLE
docs: drop Alexandria section from REVIEW.md (inherits from REVIEW_org_public)

### DIFF
--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -15,12 +15,6 @@ Ancient authors (Josephus, Eusebius, Philo, Jerome, Justin Martyr, Clement of Al
 
 **Anglophone bias warning:** AI models systematically catch English-language scholar names (MacDonald, Walsh, Whitmarsh) while missing non-English names (Schrader Polczer, de Boer, van Kooten, Tal Ilan, Young-Ho Park). Do NOT rely on "feels like a name-drop" — grep mechanically for all names appearing before `\cite{}` or with attribution verbs (argues, notes, shows, demonstrates, identifies, proposes, concludes).
 
-## Alexandria Pipeline is Internal Research Data
-
-The Alexandria extraction pipeline (`alexandria-pipelines` repo) is an internal research tool.
-References to specific data sources (e.g., "YouTube") must not appear in documentation, guidelines, or manuscript text.
-Findings from the pipeline are treated as research leads that enter the standard three-gate pipeline (ChatGPT drafting, Claude review, citation verification).
-
 ## Evidence Anchoring
 
 Every factual claim in the manuscript must be anchored to a specific primary source, inscription, or archaeological datum.


### PR DESCRIPTION
## Summary

Drops the *Alexandria Pipeline is Internal Research Data* section from `docs/REVIEW.md`. The same principle now lives org-wide as the *Primary-Source Anchoring* rule in `claude-instructions/docs/REVIEW_org_public.md` (landed via mvdatacenter/claude-instructions#151), applied to any repo that opts in via the untracked `.claude/.public` marker. This repo's marker is set to `true` locally, so the rule is inherited and the repo-local copy is redundant.

The dropped section's own example ("e.g., 'YouTube'") was the very leak it forbade. Removing it eliminates both the duplication and the leak.

## Test plan

- [ ] Confirm `docs/REVIEW.md` reads coherently with the section removed
- [ ] Confirm `.claude/.public` is set to `true` locally so the org-wide rule applies
- [ ] Confirm no remaining repo-local references to specific data sources or pipeline internals in `docs/REVIEW.md`