### PR TITLE
feat: ch5 — Atum self-generation block; Coptic ⲁⲧⲟⲩⲙ = Greek Alpha-Omega

### DIFF
--- a/chapter5.tex
+++ b/chapter5.tex
@@ -1005,6 +1005,13 @@ In the Coffin Texts, creation and life proceed explicitly by command and speech,
 Creation-by-word is therefore a systemic Egyptian doctrine spanning royal, priestly, and funerary traditions, not a single philosophical anomaly.
 Philo's Logos inherits this Egyptian creation-by-word structure, and John echoes it directly when he states that all things came into being through the Logos in John 1:1--3.
 John's Logos is cosmic and ontological rather than legal or covenantal.
+Atum extends this creator-by-word logic with self-generation.
+In the Pyramid Texts \cite[Utterance 527]{pyramidtexts}, Atum ``came into being of himself'' from the primordial waters of Nun, deriving from no prior being.
+The Coffin Texts elaborate the same self-existence (CT Spell 76), and the Book of the Dead places Atum at the beginning and end of the cosmic cycle, with the speaker declaring ``I am Atum when I was alone in Nun'' \cite[Spell 17]{bookofthedead}.
+John applies the same self-existence to the Father in John 5:26 (``the Father has life in himself'') and the same temporal priority to the Son in John 8:58 (``before Abraham was, I am'').
+The Coptic form of Atum's name, ⲁⲧⲟⲩⲙ, is built from the Greek alphabet's first and last letters: ⲁ is alpha, and the ⲟⲩⲙ ending carries the omega sound (ⲟⲩ = ō, closed by ⲙ).
+Revelation's ``the Alpha and the Omega'' is the Greek alphabet's rendering of Atum's name --- not a metaphor for divine completeness.
+Revelation 21:6 makes the identification explicit: it glosses ``the Alpha and the Omega'' as ``the Beginning and the End'' and immediately names the speaker as the giver of ``the water of life'' --- Atum's three defining attributes (self-existence at the beginning, persistence at the end, source of living existence) named in a single divine self-introduction.
 Egyptian theology also locates divine power in the revelation of the hidden name, not in covenant or law.
 In the Isis--Ra myth (Papyrus Turin 1993), Ra's secret name contains his creative \emph{dynamis} (δύναμις), ``power,'' and only when the name is revealed does Isis gain authority over him.
 The Book of the Dead turns this logic into a condition for survival after death: in Spell 17 the deceased declares ``I know the name of that god,'' and this name-knowledge grants access, protection, and life \cite[Spell 17]{bookofthedead}.


### PR DESCRIPTION
## Summary

Adds one paragraph to the Egyptian Theology in John subsection of chapter 5, between the Logos/creator-by-word block and the hidden-name block.

Establishes:
- Atum's self-generation from three Egyptian sources (Pyramid Texts Utterance 527, Coffin Texts Spell 76, Book of the Dead Spell 17 with the direct quote "I am Atum when I was alone in Nun")
- John applies the same self-existence: John 5:26 ("the Father has life in himself") and John 8:58 ("before Abraham was, I am")
- The Coptic form of Atum's name, ⲁⲧⲟⲩⲙ, is built from the Greek alphabet's first and last letters (ⲁ = alpha; ⲟⲩⲙ ending = ō + m, omega-resonant)
- Revelation's "the Alpha and the Omega" is the Greek alphabet's rendering of Atum's name, not a metaphor for divine completeness
- Rev 21:6 makes the identification explicit by glossing the title as "the Beginning and the End" and naming the speaker as the giver of "the water of life" — Atum's three defining attributes (self-existence at the beginning, persistence at the end, source of living existence) named in a single divine self-introduction

## Why this exists

First piecewise PR replacing the closed PR #121, which had grown too broad. Each follow-up PR adds one scoped piece (opener naming the 5 gods, Osiris body, recap update, etc.) so each lands on its own merits.

## Test plan

- [ ] Reads cleanly in context (lines 1007 → 1008 → 1015 transitions)
- [ ] All citations resolve (`pyramidtexts`, `coffintexts`, `bookofthedead` are existing bib keys)
- [ ] Diff is exactly 7 lines, single paragraph, no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)