### PR TITLE
docs: add Chapter 1 critical review to ch1_qa

### DIFF
--- a/scripts/ch1_qa.md
+++ b/scripts/ch1_qa.md
@@ -3,3 +3,26 @@
 ## Mystery cult framing
 
 See `scripts/global_qa.md` — book-wide decision. We reject the mystery cult framing; reframe through imperial cult under foreign rule. Extract the institutional data, discard the mystery cult conclusion.
+
+## Chapter 1 critical review (Claude pass)
+
+A critical read of the chapter against `docs/REVIEW.md` and `scripts/global_qa.md`. The chapter stays at survey register (REVIEW.md "Chapter 1 stays at survey register"), so the fixes below are precision/citation/consistency repairs, not new argument. Pure missing-citation items already catalogued in `scripts/citation_gaps.md` (Apollonius L98, Aten hymn L104, Gerasene/Polyphemus L100, Irenaeus, Josephus, etc.) are **not** repeated here — only the weak-argument and factual-exposure findings that the citation audit does not cover.
+
+This is a single-model (Claude) pass. The issue #5 second-model cross-check to reduce single-model bias is still pending: box Gemini/`agy` tooling is down (`mitmdump` missing after a pod restart) and the ChatGPT bridge requires the user to drive it. Findings here should be re-checked once a second model is available.
+
+### Unsourced statistics and factual exposure
+
+- **"oldest" NT letter.** The chapter leans on Galatians as the earliest evidence. The more defensible claim is 1 Thessalonians as the oldest surviving Pauline letter; if Galatians is meant as oldest for a specific reason, the line must state that reason. Either anchor the priority claim or soften "oldest" to "among the earliest." (Violates REVIEW.md "every factual claim cites a specific source.")
+- **Homer-vs-Septuagint fragment counts.** The "~800 Homer fragments vs 5 LXX" contrast is uncited and the "2000 BCE–200 AD" range is wrong as a bound for Homeric papyri (the Iliad/Odyssey are Archaic-era, ~8th c. BCE, and surviving papyri are Hellenistic/Roman). Cite a manuscript-census source (e.g. the Homer Multitext / Leuven Database figures) or drop the precise numbers. Invented numeric anchors are exactly what REVIEW.md "Method" forbids.
+- **Rank-Raglan scores.** The scores (Moses 20/22, Oedipus 22, Theseus 20) are stated without a source; cite Raglan's tabulation (or the standard secondary catalogue). Separately, "Greek conventions" is imprecise — Rank-Raglan is a cross-cultural hero pattern, not a Greek one; say "the hero pattern" or name the corpus. Note the two-edged-tool caveat: a high Rank-Raglan score is used by mythicists *and* applies to figures generally taken as historical, so the survey sentence should not imply the score settles historicity. "Rank-Raglan scale" itself is an eponymous standard and stays in text per REVIEW.md.
+- **"hundreds of uncanny parallels" (Apollonius).** Evidentiary-weight problem: REVIEW.md "a claim with only a `\cite{}` is not an argument." A bare "hundreds of parallels" with a Philostratus cite does not show the parallels; at survey register the one-sentence move should name the *kind* of parallel (e.g. healings, ascension) rather than assert an uncounted total.
+
+### Internal-framework consistency
+
+- **Mid-2nd-century dating.** Passages implying a mid-2nd-c. composition date conflict with the book-wide `global_qa.md` decision favoring early / fairly-early gospel dating. Reconcile to the settled framework or flag the tension explicitly.
+- **Dying-rising / mystery-rite parallels.** The chapter's dying-rising and mystery-rite language reimports the mystery-cult framing that `global_qa.md` rejects (reframe through imperial cult under foreign rule). Extract the institutional/parallel data, discard the mystery-cult conclusion. Note the Phoenician/Adonis exception that `global_qa.md` carves out — that one may stay if scoped to it.
+- **Modern scholar names in text.** Herder and the Tübingen school appear as modern attributions in prose; REVIEW.md "Modern Scholars" requires modern names to live only inside `\cite{}` (eponymous standards excepted). Move them to citations or rephrase so the idea stands on its own.
+
+### Structural gap
+
+- **Central anti-mythicist argument rests on forward references.** The section's main response to the mythicist position defers its evidence to later chapters via forward references. Verify those later chapters actually deliver the promised argument, and add explicit cross-references (chapter/section) so the survey claim is anchored rather than promissory.


### PR DESCRIPTION
## Background

Issue #5 asks to improve the Historical Jesus project with additional AI-assisted review: critique the existing analysis, identify gaps or weak arguments to strengthen, and reduce single-model bias. This PR delivers the Claude pass.

## Summary

Append a Claude-pass critical review to scripts/ch1_qa.md (issue #5). Survey-register findings against REVIEW.md and global_qa: unsourced Homer-vs-LXX fragment counts with wrong 2000 BCE bound, oldest NT-letter claim, uncited Rank-Raglan scores plus Greek imprecision and two-edged-tool caveat, bare hundreds-of-parallels evidentiary weight, mid-2nd-c dating and dying-rising/mystery-rite tensions with global_qa, modern names (Herder, Tubingen) in prose, anti-mythicist argument on forward references. Missing-citation items already in citation_gaps.md not duplicated. Single-model pass; second-model cross-check pending.
