### PR TITLE
docs: add Matthew Levi research note

### DIFF
--- a/scripts/ch5_qa.md
+++ b/scripts/ch5_qa.md
@@ -614,6 +614,7 @@ See `scripts/global_qa.md` — "Gospel localization (regional products)" for the
 - (chatgpt says...) Double genealogy (Joseph vs Mary) = normal in Herodian/Jewish royal documentation requiring parallel legal and biological lineages
 - (chatgpt says...) Sermon on the Mount's legal form = Judean halakhic discourse in Greek, matches Judean legal pedagogy
 - (chatgpt says...) Anti-Pharisee polemic = intra-Judean elite conflict, not random rural hostility
+- **Research needed; likelihood analysis required:** Check whether the Matthew/Levi call tradition supports a Jerusalem-priestly reading: Matthew 9:9 names Matthew at the tax booth, Mark 2:14 and Luke 5:27 name Levi in the same call scene, and the question is whether ``Levi'' signals Levitical/priestly lineage tied to Jerusalem or only a second name.
 - **CONCLUSION:** Matthew writes Judean political-genealogical case for Jesus's legitimacy
 
 **LUKE (Aegean): Order, chronology, census, empire obsession explained**


### PR DESCRIPTION
## Background

The user asked not to put the Matthew/Levi idea into manuscript text yet. This records the question in the existing Chapter 5 gospel-localization Q&A section, marks it as likelihood analysis required, and names the Gospel call-scene texts to check.

## Summary

Adds a Chapter 5 Q&A research-needed note to check whether the Matthew/Levi call tradition supports a Jerusalem-priestly reading before any manuscript prose uses it.

---

**Session authorship:** opened by the Codex session `019e699a-c086-70b2-a6d0-fdbf29af5b54` on host `Mac.lan` from branch `codex/matthew-levi-research-note`. Stamped by `hooks/gh-wrapper.sh` so the authoring session is visible on the PR (DD_0018).
